### PR TITLE
trigger on main branch instead of master

### DIFF
--- a/.github/workflows/backup-data-docker-image.yml
+++ b/.github/workflows/backup-data-docker-image.yml
@@ -3,7 +3,7 @@ name: Build and publish ClearlyDefined backup-data Docker image
 on:
   workflow_dispatch:
   push:
-   branches: [master]
+   branches: [main]
 
 env:
     DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository }}/backup-data


### PR DESCRIPTION
The `master` branch does not exist.  The primary branch for operations repo is `main`.