### PR TITLE
Improve error handling and logging in blobstorage-backupdata

### DIFF
--- a/tools/blobstorage-backupdata/BackupJob.cs
+++ b/tools/blobstorage-backupdata/BackupJob.cs
@@ -78,7 +78,9 @@ internal sealed class BackupJob
     {
         var retryPolicy = Policy
             .Handle<MongoConnectionException>()
+            .Or<MongoExecutionTimeoutException>()
             .Or<TimeoutException>()
+            .Or<AggregateException>()
             .WaitAndRetryAsync(new[]
             {
                 TimeSpan.FromSeconds(1),

--- a/tools/blobstorage-backupdata/Program.cs
+++ b/tools/blobstorage-backupdata/Program.cs
@@ -16,7 +16,21 @@ internal sealed class Program
         ILogger logger = loggerFactory.CreateLogger(nameof(Program));
         logger.LogInformation("Backup job started.");
         var backupJob = CreateBackupJob(loggerFactory);
-        backupJob.ProcessJob().Wait();
+        try 
+        {
+            backupJob.ProcessJob().Wait();
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.InnerExceptions)
+            {
+                logger.LogError(e, "Backup job failed.");
+            }   
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Backup job failed.");
+        }
         logger.LogInformation("Backup job completed.");
     }
 


### PR DESCRIPTION
This PR fixes two error-handling-related issues:

1. Not all the required exception types were handled by the retry policy. Fixed by extending the list of handled exceptions with the types observed during the runtime of the job.
2. No top-level error handler exists, which means when an exception is thrown, it's logged in a non-standard way, i.e. just printed to console, which might prevent log monitoring solution to miss the error. Fixed by adding a top-level error handler and logging the caught exceptions with the configured logger.