### PR TITLE
Fix error handling when polling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Tests on integration tools
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./tools/integration
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - uses: actions/setup-node@v4.0.1
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: './tools/integration/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests on tools
+        run: npm test

--- a/tools/integration/lib/harvester.js
+++ b/tools/integration/lib/harvester.js
@@ -12,13 +12,14 @@ const defaultToolChecks = [
 ]
 
 class Harvester {
-  constructor(apiBaseUrl, harvestToolChecks) {
+  constructor(apiBaseUrl, harvestToolChecks, fetch = callFetch) {
     this.apiBaseUrl = apiBaseUrl
     this.harvestToolChecks = harvestToolChecks || defaultToolChecks
+    this._fetch = fetch
   }
 
   async harvest(components, reharvest = false) {
-    return await callFetch(`${this.apiBaseUrl}/harvest`, buildPostOpts(this._buildPostJson(components, reharvest)))
+    return await this._fetch(`${this.apiBaseUrl}/harvest`, buildPostOpts(this._buildPostJson(components, reharvest)))
   }
 
   _buildPostJson(components, reharvest) {
@@ -74,7 +75,7 @@ class Harvester {
   }
 
   async fetchHarvestResult(coordinates, tool, toolVersion) {
-    return callFetch(`${this.apiBaseUrl}/harvest/${coordinates}/${tool}/${toolVersion}?form=raw`).then(r =>
+    return this._fetch(`${this.apiBaseUrl}/harvest/${coordinates}/${tool}/${toolVersion}?form=raw`).then(r =>
       r.headers.get('Content-Length') === '0' ? Promise.resolve({}) : r.json()
     )
   }

--- a/tools/integration/lib/harvester.js
+++ b/tools/integration/lib/harvester.js
@@ -38,7 +38,8 @@ class Harvester {
     }
 
     for (const coordinates of components) {
-      const completed = status.get(coordinates) || (await this.isHarvestComplete(coordinates, startTime))
+      const completed =
+        status.get(coordinates) || (await this.isHarvestComplete(coordinates, startTime).catch(() => false))
       status.set(coordinates, completed)
     }
     return status

--- a/tools/integration/test/lib/harvesterTest.js
+++ b/tools/integration/test/lib/harvesterTest.js
@@ -8,21 +8,6 @@ const Harvester = require('../../lib/harvester')
 const { devApiBaseUrl, harvestToolVersions } = require('../testConfig')
 const sinon = require('sinon')
 
-describe.skip('Integration test against dev deployment', function () {
-  it('should get harvest for a component', async function () {
-    const coordinates = 'nuget/nuget/-/NuGet.Protocol/6.7.1'
-    const result = await callFetch(`${devApiBaseUrl}/harvest/${coordinates}?form=list`).then(r => r.json())
-    ok(result.length > 0)
-  })
-
-  it('should harvest a component', async function () {
-    const coordinates = 'nuget/nuget/-/NuGet.Protocol/6.7.1'
-    const harvester = new Harvester(devApiBaseUrl)
-    const result = await harvester.harvest([coordinates])
-    strictEqual(result.status, 201)
-  })
-})
-
 describe('Tests for Harvester', function () {
   const coordinates = 'nuget/nuget/-/NuGet.Protocol/6.7.1'
 

--- a/tools/integration/test/lib/harvesterTest.js
+++ b/tools/integration/test/lib/harvesterTest.js
@@ -1,14 +1,14 @@
 // (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { strictEqual, ok } = require('assert')
+const { strictEqual, ok, deepStrictEqual } = require('assert')
 const { callFetch } = require('../../lib/fetch')
 const Poller = require('../../lib/poller')
 const Harvester = require('../../lib/harvester')
-const { devApiBaseUrl } = require('../testConfig')
+const { devApiBaseUrl, harvestToolVersions } = require('../testConfig')
 const sinon = require('sinon')
 
-describe('Integration test against dev deployment', function () {
+describe.skip('Integration test against dev deployment', function () {
   it('should get harvest for a component', async function () {
     const coordinates = 'nuget/nuget/-/NuGet.Protocol/6.7.1'
     const result = await callFetch(`${devApiBaseUrl}/harvest/${coordinates}?form=list`).then(r => r.json())
@@ -25,28 +25,71 @@ describe('Integration test against dev deployment', function () {
 
 describe('Tests for Harvester', function () {
   const coordinates = 'nuget/nuget/-/NuGet.Protocol/6.7.1'
+
   let harvester
+  let fetchStub
   beforeEach(function () {
-    harvester = new Harvester(devApiBaseUrl)
+    fetchStub = sinon.stub()
+    harvester = new Harvester(devApiBaseUrl, harvestToolVersions, fetchStub)
   })
 
-  it('should detect when a scan tool result for component is available', async function () {
-    sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata())
-    const result = await harvester.isHarvestedbyTool(coordinates, 'licensee', '9.14.0')
-    strictEqual(result, true)
+  describe('Verify api calls in harvest and fetchHarvestResult', function () {
+    it('should call correct api with the correct payload in harvest', async function () {
+      await harvester.harvest([coordinates], false)
+      const expectedPayload = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([{ tool: 'component', coordinates }])
+      }
+      ok(fetchStub.calledOnce)
+      strictEqual(fetchStub.getCall(0).args[0], `${devApiBaseUrl}/harvest`)
+      deepStrictEqual(fetchStub.getCall(0).args[1], expectedPayload)
+    })
+
+    it('should call the correct harvest api in fetchHarvestResult', async function () {
+      fetchStub.resolves(new Response(JSON.stringify({ test: true })))
+      await harvester.fetchHarvestResult(coordinates, 'licensee', '9.14.0')
+      ok(fetchStub.calledOnce)
+      strictEqual(fetchStub.getCall(0).args[0], `${devApiBaseUrl}/harvest/${coordinates}/licensee/9.14.0?form=raw`)
+    })
+
+    it('should handle in fetchHarvestResult when harvest result is not ready', async function () {
+      const response = new Response()
+      response.headers.set('Content-Length', '0')
+      fetchStub.resolves(response)
+      const result = await harvester.fetchHarvestResult(coordinates, 'licensee', '9.14.0')
+      deepStrictEqual(result, {})
+    })
   })
 
-  it('should detect when component is completely harvested', async function () {
-    sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata())
-    const result = await harvester.isHarvestComplete(coordinates)
-    strictEqual(result, true)
-  })
+  describe('isHarvested', function () {
+    beforeEach(function () {
+      harvester = new Harvester(devApiBaseUrl)
+    })
+    it('should detect when a scan tool result for component is available', async function () {
+      sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata())
+      const result = await harvester.isHarvestedbyTool(coordinates, 'licensee', '9.14.0')
+      strictEqual(result, true)
+    })
 
-  it('should detect whether component is harvested after a timestamp', async function () {
-    const date = '2023-01-01T00:00:00.000Z'
-    sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata(date))
-    const result = await harvester.isHarvestComplete(coordinates, Date.now())
-    strictEqual(result, false)
+    it('should detect when component is completely harvested', async function () {
+      sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata())
+      const result = await harvester.isHarvestComplete(coordinates)
+      strictEqual(result, true)
+    })
+
+    it('should detect whether component is harvested after a timestamp', async function () {
+      const date = '2023-01-01T00:00:00.000Z'
+      sinon.stub(harvester, 'fetchHarvestResult').resolves(metadata(date))
+      const result = await harvester.isHarvestComplete(coordinates, Date.now())
+      strictEqual(result, false)
+    })
+
+    it('should handle when harvest result is not ready', async function () {
+      sinon.stub(harvester, 'fetchHarvestResult').resolves({})
+      const result = await harvester.isHarvestComplete(coordinates)
+      strictEqual(result, false)
+    })
   })
 })
 

--- a/tools/integration/test/testConfig.js
+++ b/tools/integration/test/testConfig.js
@@ -45,6 +45,6 @@ module.exports = {
     timeout: 1000 * 60 * 60 * 2 // 2 hours for harvesting all the components
   },
   definition: {
-    timeout: 1000 * 5 // 5 seconds for each component
+    timeout: 1000 * 10 // for each component
   }
 }


### PR DESCRIPTION
- Fixed error handling when polling
- Adjust test configuration to avoid timeout.
- Added GitHub Action to run unit tests on tools upon pull and push. An example run can be found [here](https://github.com/qtomlinson/operations/actions/runs/8271676207)
- Added more unit tests to verify api call details, and disable calling dev server during unit tests.