### PR TITLE
coordinate reusable workflow by assigning release v1.0.0

### DIFF
--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -1,4 +1,8 @@
 # This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
+# v1.0.0 - This tag coordinates the other reusable parts of this workflow.
+#   * app-build-docker-image.yml
+#   * app-deploy-to-azure.yml
+#   * app-is-deployable.yml
 name: Build and Deploy to prod service app
 
 on:
@@ -81,7 +85,7 @@ jobs:
   build-and-publish-image:
     name: Build and publish Docker image
     needs: get-version
-    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@elr/reusable-deploy-workflow
+    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@v1.0.0
     secrets:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
@@ -93,7 +97,7 @@ jobs:
   deploy-primary-app-to-azure:
     name: Deploy to primary Azure app
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@elr/reusable-deploy-workflow
+    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.0.0
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
@@ -109,7 +113,7 @@ jobs:
     name: Deploy to secondary Azure app
     if: ${{ inputs.secondary-azure-app-name-postfix != '' }}
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@elr/reusable-deploy-workflow
+    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.0.0
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_SECONDARY_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@elr/reusable-deploy-workflow
+    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.0.0
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:

--- a/.github/workflows/app-deploy-to-azure.yml
+++ b/.github/workflows/app-deploy-to-azure.yml
@@ -37,7 +37,7 @@ on:
         
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@elr/reusable-deploy-workflow
+    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.0.0
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:


### PR DESCRIPTION
### Description

Workflows require a reference that is a branch, tag, or commit.  It is easier to read if a release is created resulting in a release tag.  This is the first release and will be assigned the v1.0.0 tag.  

Considerations: 
* All parts of the reusable workflows will use the same tag. 
* A change to the any of the related workflows will require...
    * determine the next version according to semver
    * each part of the related reusable workflows will need to be updated to reference each other at the new version
    * after merged to main, create a release at the new version
* There are other tools maintained in this repository.  Any of them need to be able to create a release.  No need to update the reusable workflows' version if none of the related workflows are changed.

### Related Workflows

This PR is setting the following related workflows to the v1.0.0 version.  This is required ahead of creating the release so they are all on the v1.0.0 tag.

* app-build-and-deploy.yml
* app-build-docker-image.yml
* app-deploy-to-azure.yml
* app-is-deployable.yml
