### PR TITLE
move is-release check to reusable workflow

### DIFF
--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -45,15 +45,23 @@ on:
         description: 'postfix to apply to the base name for a secondary deploy site (e.g. -prod-europe, do not specify if no secondary site)'
         type: string
         default: ''
-      is-release:
-        description: 'true only when triggered by a release; otherwise false when dev deploy or manually deploy of prod'
-        type: boolean
-        default: false   
 
 jobs:
+  determine-trigger:
+    name: Determine if this was triggered by a release or workflow_dispatch
+    runs-on: ubuntu-latest
+    outputs:
+      is-release: ${{ env.IS_RELEASE }}
+    steps:
+      - name: Check if this was triggered by a release
+        id: release
+        run: |
+          echo "IS_RELEASE"=${{ github.event_name == 'release' }} >> $GITHUB_ENV
+
   get-version:
     name: Get version from package-lock.json
     runs-on: ubuntu-latest
+    needs: determine-trigger
     outputs:
       version: ${{ env.VERSION }}
     steps:
@@ -64,7 +72,7 @@ jobs:
         run: |
           version='v'$(jq -r '.version' package-lock.json)       # e.g. v1.2.0
           if [[ ${{ inputs.deploy-env }} == 'prod' ]]; then
-            if [[ ${{ inputs.is-release }} == 'true' ]]; then
+            if [[ ${{ needs.determine-trigger.outputs.is-release }} == 'true' ]]; then
               # validate the version when triggered by a release
               if [[ $version != 'v'${{ github.event.release.tag_name }} ]]; then
                 echo "Version in package-lock.json ($version) does not match the release tag (${{ github.event.release.tag_name }})"

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -1,5 +1,5 @@
 # This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
-# v1.0.0 - This tag coordinates the other reusable parts of this workflow.
+# v1.1.0 - This tag coordinates the other reusable parts of this workflow.
 #   * app-build-docker-image.yml
 #   * app-deploy-to-azure.yml
 #   * app-is-deployable.yml
@@ -93,7 +93,7 @@ jobs:
   build-and-publish-image:
     name: Build and publish Docker image
     needs: get-version
-    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@v1.1.0
     secrets:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
@@ -105,7 +105,7 @@ jobs:
   deploy-primary-app-to-azure:
     name: Deploy to primary Azure app
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.1.0
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
@@ -121,7 +121,7 @@ jobs:
     name: Deploy to secondary Azure app
     if: ${{ inputs.secondary-azure-app-name-postfix != '' }}
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v1.1.0
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_SECONDARY_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.1.0
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:

--- a/.github/workflows/app-deploy-to-azure.yml
+++ b/.github/workflows/app-deploy-to-azure.yml
@@ -37,7 +37,7 @@ on:
         
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v1.1.0
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:


### PR DESCRIPTION
There was a bug receiving `is-release` as a `boolean`.  Instead of making all callers know they need to pass `'true'` instead of `true`, it is better to move the check here.

This will be made available as tag v1.1.0