### PR TITLE
Improve definition comparison

### DIFF
--- a/tools/integration/test/e2e-test-service/definitionTest.js
+++ b/tools/integration/test/e2e-test-service/definitionTest.js
@@ -1,7 +1,7 @@
 // (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { omit, isEqual } = require('lodash')
+const { omit, isEqual, pick } = require('lodash')
 const { deepStrictEqual, strictEqual } = require('assert')
 const { callFetch, buildPostOpts } = require('../../lib/fetch')
 const { devApiBaseUrl, prodApiBaseUrl, expectedResponses, components, definition } = require('../testConfig')
@@ -77,14 +77,16 @@ function compareDefinition(recomputedDef, expectedDef) {
 }
 
 function compareLicensed(result, expectation) {
-  const actual = omit(result.licensed, ['facets'])
+  let actual = omit(result.licensed, ['facets'])
   const expected = omit(expectation.licensed, ['facets'])
+  actual = pick(actual, Object.keys(expected))
   deepStrictEqual(actual, expected)
 }
 
 function compareDescribed(result, expectation) {
-  const actual = omit(result.described, ['tools'])
+  let actual = omit(result.described, ['tools'])
   const expected = omit(expectation.described, ['tools'])
+  actual = pick(actual, Object.keys(expected))
   deepStrictEqual(actual, expected)
 }
 


### PR DESCRIPTION
The recent harvested definition for crate/cratesio/-/ratatui/0.26.0 contained projectWebsite information.  This information was missing in the previous result.  Adapt the verification to only compare the existing fields in the expected result.