### PR TITLE
Use the new traversal policy to simplify reharvest

### DIFF
--- a/tools/integration/lib/harvester.js
+++ b/tools/integration/lib/harvester.js
@@ -20,7 +20,7 @@ class Harvester {
     const tool = this._harvestToolChecks?.length === 1 ? this._harvestToolChecks[0][0] : 'component'
     return components.map(coordinates => {
       const result = { tool, coordinates }
-      if (reharvest) result.policy = 'always'
+      if (reharvest) result.policy = 'reharvestAlways'
       return result
     })
   }
@@ -57,10 +57,6 @@ class Harvester {
     if (!component) throw new Error('Component not set')
     console.log('Start to detect schema versions for harvest tools')
     const startTime = Date.now()
-    //make sure that we have one entire set of harvest results (old or new)
-    await this.harvest([component])
-    await new Promise(resolve => setTimeout(resolve, poller.interval))
-
     //trigger a reharvest to overwrite the old result, so we can verify the timestamp is new for completion
     await this.harvest([component], true)
 

--- a/tools/integration/test/integration/harvestTest.js
+++ b/tools/integration/test/integration/harvestTest.js
@@ -28,18 +28,9 @@ async function harvestTillCompletion(components) {
   const versionPoller = new Poller(poll.interval / 5, poll.maxTime)
   await harvester.detectSchemaVersions(oneComponent, versionPoller, tools)
 
-  //make sure that we have one entire set of harvest results (old or new)
-  console.log('Ensure harvest results exist before starting tests')
-  const previousHarvests = await harvester.pollForCompletion(components, new Poller(1, 1))
-  const previousHarvestsComplete = Array.from(previousHarvests.values()).every(v => v)
-  const poller = new Poller(poll.interval, poll.maxTime)
-  if (!previousHarvestsComplete) {
-    await harvester.harvest(components)
-    await harvester.pollForCompletion(components, poller)
-  }
-
   //trigger a reharvest to overwrite the old result
   console.log('Trigger reharvest to overwrite old results')
   await harvester.harvest(components, true)
+  const poller = new Poller(poll.interval, poll.maxTime)
   return harvester.pollForCompletion(components, poller, Date.now())
 }


### PR DESCRIPTION
Previously, the "always" traversal policy was used to retrigger the harvest of a component. This policy essentially reran all the previously successfully executed tools.  This can be quite cumbersome, especially for integration tests. Sometimes, certain tool results were not available, such as when the schema version had been updated, causing the previously harvested results to become stale and the tool results with the newly updated schema version to be missing.  When the tool result for a specific component is missing, using the "always" policy leads to a "Unreachable for reprocessing " status and the tool being skipped.
                                     
To address this issue in integration testing, the approach was to first trigger a round of harvest using the default traversal policy. With the default policy, the tools would run for the component if there were no existing results with the correct schema version. If there were previous results, the tools would skip and use the existing results with the current schema version. This initial run was to ensure a complete set of tool results (both new and old) were available for the correct schema version. Upon completion of the first run, a re-harvest was triggered with "always" traversal policy so that all the tools were rerun and the tool results were updated.
                                      
With the introduction of the "reharvestAlways" traversal policy (https://github.com/clearlydefined/crawler/pull/598), the integration tests can now be simplified.  This PR handles the adaptation.