### PR TITLE
add version and sha in docker image instead of Azure configs

### DIFF
--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -125,7 +125,7 @@ jobs:
     name: Deploy to secondary Azure app
     if: ${{ inputs.secondary-azure-app-name-postfix != '' }}
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v2.0.0
+    uses: ./.github/workflows/app-deploy-to-azure.yml
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_SECONDARY_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -119,7 +119,6 @@ jobs:
     with:
       deploy-env: ${{ inputs.deploy-env }}
       azure-webapp-name: ${{ inputs.azure-app-base-name }}${{ inputs.azure-app-name-postfix }}
-      application-version: ${{ needs.get-version.outputs.version }}
       image-name-with-tag: ${{ needs.build-and-publish-image.outputs.docker-image-name-with-tag }}
 
   deploy-secondary-app-to-azure:

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -104,7 +104,7 @@ jobs:
     with:
       deploy-env: ${{ inputs.deploy-env }}
       application-type: ${{ inputs.application-type }}
-      image-tag: ${{ needs.get-version.outputs.version }}
+      application-version: ${{ needs.get-version.outputs.version }}
       build-args: ${{ inputs.docker-build-args }}
 
   deploy-primary-app-to-azure:

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -1,5 +1,5 @@
 # This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
-# v2.0.0 - This tag coordinates the other reusable parts of this workflow.
+# v3.0.0 - This tag coordinates the other reusable parts of this workflow.
 #   * app-build-docker-image.yml
 #   * app-deploy-to-azure.yml
 #   * app-is-deployable.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.0.0'
           path: 'operations'
       - name: Get version from package-lock.json
         id: get_version

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -97,7 +97,7 @@ jobs:
   build-and-publish-image:
     name: Build and publish Docker image
     needs: get-version
-    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@53af332301d9a2f47cc62769c9b86f3460b79270
+    uses: ./.github/workflows/app-build-docker-image.yml
     secrets:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
@@ -110,7 +110,7 @@ jobs:
   deploy-primary-app-to-azure:
     name: Deploy to primary Azure app
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@53af332301d9a2f47cc62769c9b86f3460b79270
+    uses: ./.github/workflows/app-deploy-to-azure.yml
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -97,7 +97,7 @@ jobs:
   build-and-publish-image:
     name: Build and publish Docker image
     needs: get-version
-    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@v2.0.0
+    uses: clearlydefined/operations/.github/workflows/app-build-docker-image.yml@53af332301d9a2f47cc62769c9b86f3460b79270
     secrets:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
@@ -110,7 +110,7 @@ jobs:
   deploy-primary-app-to-azure:
     name: Deploy to primary Azure app
     needs: [get-version, build-and-publish-image]
-    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@v2.0.0
+    uses: clearlydefined/operations/.github/workflows/app-deploy-to-azure.yml@53af332301d9a2f47cc62769c9b86f3460b79270
     secrets:
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -134,5 +134,4 @@ jobs:
     with:
       deploy-env: ${{ inputs.deploy-env }}
       azure-webapp-name: ${{ inputs.azure-app-base-name }}${{ inputs.secondary-azure-app-name-postfix }}
-      application-version: ${{ needs.get-version.outputs.version }}
       image-name-with-tag: ${{ needs.build-and-publish-image.outputs.docker-image-name-with-tag }}

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -20,7 +20,7 @@ on:
         description: 'application type (i.e. api | worker | ui) - used as a label for the Docker image'
         required: true
         type: string
-      image-tag:
+      application-version:
         description: 'the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)'
         required: true
         type: string
@@ -61,7 +61,7 @@ jobs:
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
             "${{ github.repository }}" \
             "${{ inputs.deploy-env }}" \
-            "${{ inputs.image-tag }}") || (echo "$script_log" && exit 1)
+            "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
           echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
@@ -87,7 +87,11 @@ jobs:
           context: .
           push: true
           file: Dockerfile
-          build-args: ${{ inputs.build-args }}
+          build-args: |
+            APP_VERSION=${{ inputs.application-version }}
+            BUILD_SHA=${{ github.sha }}
+            BUILD_NUMBER=${{ inputs.application-version }}
+            ${{ inputs.build-args }}
           tags: ${{ needs.determine-image-name.outputs.docker-image-name-with-tag }}
           labels: |
             env=${{ inputs.deploy-env }}

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -80,6 +80,13 @@ jobs:
           username: ${{ github.actor }} # user that kicked off the action
           password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
+      - name: Log into Docker Hub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: 
+
+
+
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v5.2.0
@@ -90,7 +97,6 @@ jobs:
           build-args: |
             APP_VERSION=${{ inputs.application-version }}
             BUILD_SHA=${{ github.sha }}
-            BUILD_NUMBER=${{ inputs.application-version }}
             ${{ inputs.build-args }}
           tags: ${{ needs.determine-image-name.outputs.docker-image-name-with-tag }}
           labels: |

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v2.0.0
+    uses: ./.github/workflows/app-is-deployable.yml
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -80,13 +80,6 @@ jobs:
           username: ${{ github.actor }} # user that kicked off the action
           password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
-      - name: Log into Docker Hub
-        uses: docker/login-action@v3.0.0
-        with:
-          username: 
-
-
-
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v5.2.0

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.0.0'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name

--- a/.github/workflows/app-deploy-to-azure.yml
+++ b/.github/workflows/app-deploy-to-azure.yml
@@ -33,7 +33,7 @@ on:
         
 jobs:
   check-deployable:
-    uses: clearlydefined/operations/.github/workflows/app-is-deployable.yml@v2.0.0
+    uses: ./.github/workflows/app-is-deployable.yml
     with:
       deploy-env: ${{ inputs.deploy-env }}
     secrets:

--- a/.github/workflows/app-deploy-to-azure.yml
+++ b/.github/workflows/app-deploy-to-azure.yml
@@ -26,10 +26,6 @@ on:
         description: 'Azure application name of application to deploy (i.e. clearlydefined-api | cdcrawler | clearlydefined)'
         required: true
         type: string
-      application-version:
-        description: 'the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)'
-        required: true
-        type: string
       image-name-with-tag:
         description: 'Docker image name with the tag (e.g. ghcr.io/clearlydefined/clearlydefined-api:v1.2.0)'
         required: true
@@ -68,16 +64,6 @@ jobs:
               {
                 "name": "DOCKER_REGISTRY_SERVER_URL",
                 "value": "https://ghcr.io",
-                "slotSetting": false
-              },
-              {
-                "name": "APP_VERSION",
-                "value": "${{ inputs.application-version }}",
-                "slotSetting": false
-              },
-              {
-                "name": "BUILD_SHA",
-                "value": "${{ github.sha }}",
                 "slotSetting": false
               }
             ]

--- a/.github/workflows/app-is-deployable.yml
+++ b/.github/workflows/app-is-deployable.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.0.0'
           path: 'operations'
       - id: confirm-dev
         shell: bash
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.0.0'
           path: 'operations'
 
       - name: Get organization ID


### PR DESCRIPTION
### Description

This sets up the docker image to hold the version and sha that are used to verify which version is actually running.  The previous approach used Azure configs that get set just before the deploy.  If the deploy were to fail, those configs stay the same leading to a false report on the version and sha.

### Related Work

* https://github.com/clearlydefined/service/pull/1199
* https://github.com/clearlydefined/crawler/pull/574

### Remaining Work

* add status check with version and sha to website
* consider using a different endpoint (e.g. status-check) for all 3 major apps because the website will not be able to use `/` because that goes to a page that already has content (i.e. homepage)
* after this PR is merged
  * update the version in all `app_` workflows and release
  * update workflows using the operations `app_` workflows to reference the new release
 