### PR TITLE
Fix https://github.com/clearlydefined/operations/issues/95

### DIFF
--- a/tools/blobstorage-backupdata/BackupData.csproj
+++ b/tools/blobstorage-backupdata/BackupData.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>BackupData.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.15.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />

--- a/tools/blobstorage-backupdata/BackupJob.cs
+++ b/tools/blobstorage-backupdata/BackupJob.cs
@@ -21,7 +21,7 @@ internal sealed class BackupJob
     private static readonly object LockObject = new();
     private static int counter;
     private const string DateTimeFormat = "yyyy-MM-dd-HH";
-    private const int BatchSize = 10000;
+    private const int BatchSize = 1000;
     private const string UpdatedFieldName = "_meta.updated";
     private const string MetaFieldName = "_meta";
 

--- a/tools/blobstorage-backupdata/Dockerfile
+++ b/tools/blobstorage-backupdata/Dockerfile
@@ -1,11 +1,11 @@
 # Use the official image as a parent image
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 LABEL org.opencontainers.image.source="https://github.com/clearlydefined/operations"
 LABEL org.opencontainers.image.description="ClearlyDefined publish changes job"
 WORKDIR /app
 
 # Use the SDK image to build the app
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /src
 COPY ["BackupData.csproj", "BackupData/"]
 RUN dotnet restore "BackupData/BackupData.csproj"

--- a/tools/blobstorage-backupdata/Program.cs
+++ b/tools/blobstorage-backupdata/Program.cs
@@ -7,25 +7,19 @@ using MongoDB.Driver;
 
 internal sealed class Program
 {
-    internal static void Main()
+    internal static async Task Main()
     {
+        DotNetEnv.Env.Load();
         string? useJsonLoggingEnvVar = Environment.GetEnvironmentVariable("USE_JSON_LOGGING");
         _ = bool.TryParse(useJsonLoggingEnvVar, out bool useJsonLogging);
         using ILoggerFactory loggerFactory = CustomLoggerFactory.Create(useJsonLogging);
 
         ILogger logger = loggerFactory.CreateLogger(nameof(Program));
         logger.LogInformation("Backup job started.");
-        var backupJob = CreateBackupJob(loggerFactory);
         try 
         {
-            backupJob.ProcessJob().Wait();
-        }
-        catch (AggregateException ae)
-        {
-            foreach (var e in ae.InnerExceptions)
-            {
-                logger.LogError(e, "Backup job failed.");
-            }   
+            var backupJob = CreateBackupJob(loggerFactory);
+            await backupJob.ProcessJob();
         }
         catch (Exception e)
         {


### PR DESCRIPTION
This change mainly reduces the CosmosDB batch size to get rid of the exception mentioned in the #95. The other changes here are upgrades, such as moving to current .NET LTS. 

As a small convenience addition, `DotNetEnv.Env.Load()` allows running the program locally with a `.env` file.