### PR TITLE
Deploy image to docker optionally, as well as GHCR

### DIFF
--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -57,7 +57,6 @@ on:
         required: false
         type: string
     
-
 jobs:
   determine-trigger:
     name: Determine if this was triggered by a release or workflow_dispatch
@@ -86,8 +85,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          # ref: 'v3.0.0'
-          ref: '73e1d7a7e30df3235db59a0eeafaa21c25784134'
+          ref: 'v3.1.0'
           path: 'operations'
       - name: Get version from package-lock.json
         id: get_version

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.0.0'
+          ref: 'v2.0.0'
           path: 'operations'
       - name: Get version from package-lock.json
         id: get_version

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -108,6 +108,7 @@ jobs:
     secrets:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} 
     with:
       deploy-env: ${{ inputs.deploy-env }}
       application-type: ${{ inputs.application-type }}

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.1.0'
           path: 'operations'
       - name: Get version from package-lock.json
         id: get_version

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -23,6 +23,9 @@ on:
       PRODUCTION_DEPLOYERS:
         description: 'Name of the team that defines who can deploy to production - Defined in org action secrets'
         required: true
+      DOCKERHUB_TOKEN: 
+        description: 'Token to be used if publishing image to dockerhub, input.docker-hub-username must also be provided'
+        required: false
 
     inputs:
       deploy-env:
@@ -47,6 +50,10 @@ on:
         default: ''
       docker-build-args:
         description: 'optionally pass in build args to the Docker build command (e.g. "MY_VAR=my_value")'
+        required: false
+        type: string
+      docker-hub-username:
+        description: 'optionally pass to publish image to docker-hub'
         required: false
         type: string
     
@@ -106,6 +113,7 @@ jobs:
       application-type: ${{ inputs.application-type }}
       application-version: ${{ needs.get-version.outputs.version }}
       build-args: ${{ inputs.docker-build-args }}
+      docker-hub-username: ${{ inputs.docker-hub-username }}
 
   deploy-primary-app-to-azure:
     name: Deploy to primary Azure app

--- a/.github/workflows/app-build-and-deploy.yml
+++ b/.github/workflows/app-build-and-deploy.yml
@@ -86,7 +86,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.1.0'
+          # ref: 'v3.0.0'
+          ref: '73e1d7a7e30df3235db59a0eeafaa21c25784134'
           path: 'operations'
       - name: Get version from package-lock.json
         id: get_version

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'd6f322edeaf369efb34d6b68582f8d90f54f222d'
+          ref: '3.1.0'
           path: 'operations'
       - name: Determine gchr Image Name
         id: determine_gchr_image_name
@@ -89,33 +89,6 @@ jobs:
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
           echo "DOCKERHUB_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
-
-  # determine-dockerhub-image-name:
-  #   name: Determine Image Name
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
-  #   steps:
-  #     - name: Checkout this repo
-  #       if: ${{ inputs.docker-hub-username != '' }}
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         repository: 'clearlydefined/operations'
-  #         ref: '3b4ec17688a881e77b35c16f3f758fc2705a1e8d'
-  #         path: 'operations'
-  #     - name: Determine Docker Image Name
-  #       if: ${{ inputs.docker-hub-username != '' }}
-  #       id: determine_image_name
-  #       run: |
-  #         echo "BUILD_ARGS=${{ inputs.build-args }}"
-  #         script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
-  #           "${{ inputs.docker-hub-username }}" \
-  #           "${{ github.repository }}" \
-  #           "${{ inputs.deploy-env }}" \
-  #           "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
-  #         echo -e "---- script log\n$script_log\n----"; \
-  #         image_name=$(echo "$script_log" | tail -n 1)
-  #         echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
   build-docker-image:
     name: Build Image

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Log into Docker Hub
         if: ${{ inputs.docker-hub-username != '' }}
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ inputs.docker-hub-username }} 
           password: ${{ secrets.DOCKERHUB_TOKEN }} 

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -87,7 +87,7 @@ jobs:
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
-          echo "DOCKER_IMAGE_NAME_WITH_TAG=\n$image_name" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_NAME_WITH_TAG="${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"$'\n'"$image_name"" >> $GITHUB_ENV
 
   # determine-dockerhub-image-name:
   #   name: Determine Image Name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
 
-  determine-image-name:
+  determine-ghcr-image-name:
     name: Determine Image Name
     runs-on: ubuntu-latest
     outputs:
@@ -67,6 +67,33 @@ jobs:
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
+            "ghcr.io" \
+            "${{ github.repository }}" \
+            "${{ inputs.deploy-env }}" \
+            "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
+          echo -e "---- script log\n$script_log\n----"; \
+          image_name=$(echo "$script_log" | tail -n 1)
+          echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
+
+  determine-dockerhub-image-name:
+    if: ${{ inputs.docker-hub-username != '' }}
+    name: Determine Image Name
+    runs-on: ubuntu-latest
+    outputs:
+      docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: 'clearlydefined/operations'
+          ref: 'v2.0.0'
+          path: 'operations'
+      - name: Determine Docker Image Name
+        id: determine_image_name
+        run: |
+          echo "BUILD_ARGS=${{ inputs.build-args }}"
+          script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
+            "${{ inputs.docker-hub-username }}" \
             "${{ github.repository }}" \
             "${{ inputs.deploy-env }}" \
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
@@ -77,16 +104,9 @@ jobs:
   build-docker-image:
     name: Build Image
     runs-on: ubuntu-latest
-    needs: [check-deployable, determine-image-name]
+    needs: [check-deployable, determine-ghcr-image-name, determine-dockerhub-image-name]
     steps:
       - uses: actions/checkout@v4.1.1
-
-      - name: Log into ghcr registry
-        uses: docker/login-action@v3.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }} # user that kicked off the action
-          password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Log into Docker Hub
         if: ${{ inputs.docker-hub-username != '' }}
@@ -94,6 +114,13 @@ jobs:
         with:
           username: ${{ inputs.docker-hub-username }} 
           password: ${{ secrets.DOCKERHUB_TOKEN }} 
+
+      - name: Log into ghcr registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }} # user that kicked off the action
+          password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Build and push Docker image
         id: build-and-push
@@ -106,7 +133,9 @@ jobs:
             APP_VERSION=${{ inputs.application-version }}
             BUILD_SHA=${{ github.sha }}
             ${{ inputs.build-args }}
-          tags: ${{ needs.determine-image-name.outputs.docker-image-name-with-tag }}
+          tags: |
+            ${{ needs.determine-ghcr-image-name.outputs.docker-image-name-with-tag }}
+            ${{ needs.determine-dockerhub-image-name.outputs.docker-image-name-with-tag }}
           labels: |
             env=${{ inputs.deploy-env }}
             type=${{ inputs.application-type }}          

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.0.0'
+          ref: '2.0.0'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -149,7 +149,7 @@ jobs:
             BUILD_SHA=${{ github.sha }}
             ${{ inputs.build-args }}
           tags: |
-            ${{ needs.determine-ghcr-image-name.outputs.docker-image-name-with-tag }}
+            ${{ needs.determine-image-name.outputs.docker-image-name-with-tag }}
           labels: |
             env=${{ inputs.deploy-env }}
             type=${{ inputs.application-type }}          

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Log into Docker Hub
         uses: docker/login-action@v3.0.0
         with:
-          username: 
-
+          username: ${{ inputs.DOCKERHUB_USERNAME }} 
+          password: ${{ secrets.DOCKERHUB_TOKEN }} 
 
 
       - name: Build and push Docker image

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -10,6 +10,10 @@ on:
       PRODUCTION_DEPLOYERS:
         description: 'Name of the team that defines who can deploy to production - Defined in org action secrets'
         required: true
+      DOCKERHUB_TOKEN: 
+        description: 'Token to be used if publishing image to dockerhub, input.docker-hub-username must also be provided'
+        required: false
+
 
     inputs:
       deploy-env:
@@ -26,6 +30,10 @@ on:
         type: string
       build-args:
         description: 'optionally pass in build args to the Docker build command (e.g. "MY_VAR=my_value")'
+        required: false
+        type: string
+      docker-hub-username:
+        description: 'optionally pass to publish image to docker-hub'
         required: false
         type: string
       
@@ -81,11 +89,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Log into Docker Hub
+        if: ${{ inputs.docker-hub-username != '' }}
         uses: docker/login-action@v3.0.0
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }} 
+          username: ${{ inputs.docker-hub-username }} 
           password: ${{ secrets.DOCKERHUB_TOKEN }} 
-
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -81,7 +81,7 @@ jobs:
         if: ${{ inputs.docker-hub-username != '' }}
         id: add-dockerhub
         run: |
-          echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_TAGS }},${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_IMAGE_TAGS }},${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
 
   build-docker-image:

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
 
-  determine-ghcr-image-name:
+  determine-image-name:
     name: Determine Image Name
     runs-on: ubuntu-latest
     outputs:
@@ -119,7 +119,7 @@ jobs:
   build-docker-image:
     name: Build Image
     runs-on: ubuntu-latest
-    needs: [check-deployable, determine-ghcr-image-name, determine-dockerhub-image-name]
+    needs: [check-deployable, determine-image-name]
     steps:
       - uses: actions/checkout@v4.1.1
 

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -62,8 +62,8 @@ jobs:
           repository: 'clearlydefined/operations'
           ref: '3adf6fb9656eee09cd8afbd6cffbff5da29a30d6'
           path: 'operations'
-      - name: Determine Docker Image Name
-        id: determine_image_name
+      - name: Determine gchr Image Name
+        id: determine_gchr_image_name
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
@@ -75,22 +75,9 @@ jobs:
           image_name=$(echo "$script_log" | tail -n 1)
           echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
-  determine-dockerhub-image-name:
-    name: Determine Image Name
-    runs-on: ubuntu-latest
-    outputs:
-      docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
-    steps:
-      - name: Checkout this repo
+      - name: Determine Dockerhub Image Name
         if: ${{ inputs.docker-hub-username != '' }}
-        uses: actions/checkout@v4.1.1
-        with:
-          repository: 'clearlydefined/operations'
-          ref: '3b4ec17688a881e77b35c16f3f758fc2705a1e8d'
-          path: 'operations'
-      - name: Determine Docker Image Name
-        if: ${{ inputs.docker-hub-username != '' }}
-        id: determine_image_name
+        id: determine_dockerhub_name
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
@@ -100,7 +87,34 @@ jobs:
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
-          echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_NAME_WITH_TAG=\n$image_name" >> $GITHUB_ENV
+
+  # determine-dockerhub-image-name:
+  #   name: Determine Image Name
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
+  #   steps:
+  #     - name: Checkout this repo
+  #       if: ${{ inputs.docker-hub-username != '' }}
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         repository: 'clearlydefined/operations'
+  #         ref: '3b4ec17688a881e77b35c16f3f758fc2705a1e8d'
+  #         path: 'operations'
+  #     - name: Determine Docker Image Name
+  #       if: ${{ inputs.docker-hub-username != '' }}
+  #       id: determine_image_name
+  #       run: |
+  #         echo "BUILD_ARGS=${{ inputs.build-args }}"
+  #         script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
+  #           "${{ inputs.docker-hub-username }}" \
+  #           "${{ github.repository }}" \
+  #           "${{ inputs.deploy-env }}" \
+  #           "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
+  #         echo -e "---- script log\n$script_log\n----"; \
+  #         image_name=$(echo "$script_log" | tail -n 1)
+  #         echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
   build-docker-image:
     name: Build Image

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -79,7 +79,7 @@ jobs:
           echo "DOCKER_IMAGE_TAGS=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
       - name: add-dockerhub
         if: ${{ inputs.docker-hub-username != '' }}
-        id: add dockerhub image if required
+        id: add-dockerhub
         run: |
           echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_TAGS }},${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
@@ -90,7 +90,6 @@ jobs:
     needs: [check-deployable, build-image-names]
     steps:
       - uses: actions/checkout@v4.1.1
-
       - name: Log into Docker Hub
         if: ${{ inputs.docker-hub-username != '' }}
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -63,7 +63,7 @@ jobs:
           ref: '5ef92010ae13ec5263ee7509311dbb1f2edac44c'
           path: 'operations'
       - name: Determine Image Name
-        id: determine_image_name
+        id: determine-image-name
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
@@ -74,10 +74,10 @@ jobs:
           image_name=$(echo "$script_log" | tail -n 1)
           echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
       - name: Add ghcr.io 
-        id: add dockerhub image if required
+        id: add-ghcr
         run: |
           echo "DOCKER_IMAGE_TAGS=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
-      - name: Add Dockerhub if required
+      - name: add-dockerhub
         if: ${{ inputs.docker-hub-username != '' }}
         id: add dockerhub image if required
         run: |

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: '3adf6fb9656eee09cd8afbd6cffbff5da29a30d6'
+          ref: '3b4ec17688a881e77b35c16f3f758fc2705a1e8d'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: '3adf6fb9656eee09cd8afbd6cffbff5da29a30d6'
+          ref: 'd6f322edeaf369efb34d6b68582f8d90f54f222d'
           path: 'operations'
       - name: Determine gchr Image Name
         id: determine_gchr_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -76,19 +76,20 @@ jobs:
           echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
   determine-dockerhub-image-name:
-    if: ${{ inputs.docker-hub-username != '' }}
     name: Determine Image Name
     runs-on: ubuntu-latest
     outputs:
       docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
     steps:
       - name: Checkout this repo
+        if: ${{ inputs.docker-hub-username != '' }}
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
           ref: '3b4ec17688a881e77b35c16f3f758fc2705a1e8d'
           path: 'operations'
       - name: Determine Docker Image Name
+        if: ${{ inputs.docker-hub-username != '' }}
         id: determine_image_name
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: '2.0.0'
+          ref: 'v2.0.0'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: '3.1.0'
+          ref: '5ef92010ae13ec5263ee7509311dbb1f2edac44c'
           path: 'operations'
       - name: Determine Image Name
         id: determine_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -54,7 +54,8 @@ jobs:
     name: Determine Image Name
     runs-on: ubuntu-latest
     outputs:
-      docker-image-name-with-tag: "${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"
+      gchr-docker-image-name-with-tag: "${{ env.GCHR_DOCKER_IMAGE_NAME_WITH_TAG }}"
+      dockerhub-image-name-with-tag: "${{ env.DOCKERHUB_IMAGE_NAME_WITH_TAG }}"
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4.1.1
@@ -73,7 +74,7 @@ jobs:
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
-          echo "DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
+          echo "GCHR_DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
       - name: Determine Dockerhub Image Name
         if: ${{ inputs.docker-hub-username != '' }}
@@ -87,7 +88,7 @@ jobs:
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
-          echo "DOCKER_IMAGE_NAME_WITH_TAG="${{ env.DOCKER_IMAGE_NAME_WITH_TAG }}"$'\n'"$image_name"" >> $GITHUB_ENV
+          echo "DOCKERHUB_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
 
   # determine-dockerhub-image-name:
   #   name: Determine Image Name
@@ -149,7 +150,8 @@ jobs:
             BUILD_SHA=${{ github.sha }}
             ${{ inputs.build-args }}
           tags: |
-            ${{ needs.determine-image-name.outputs.docker-image-name-with-tag }}
+            ${{ needs.determine-image-name.outputs.gchr-docker-image-name-with-tag }}
+            ${{ needs.determine-image-name.outputs.dockerhub-image-name-with-tag }}
           labels: |
             env=${{ inputs.deploy-env }}
             type=${{ inputs.application-type }}          

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: '3adf6fb9656eee09cd8afbd6cffbff5da29a30d6'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: '3adf6fb9656eee09cd8afbd6cffbff5da29a30d6'
           path: 'operations'
       - name: Determine Docker Image Name
         id: determine_image_name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: '5ef92010ae13ec5263ee7509311dbb1f2edac44c'
+          ref: '3.1.0'
           path: 'operations'
       - name: Determine Image Name
         id: determine-image-name

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -150,7 +150,6 @@ jobs:
             ${{ inputs.build-args }}
           tags: |
             ${{ needs.determine-ghcr-image-name.outputs.docker-image-name-with-tag }}
-            ${{ needs.determine-dockerhub-image-name.outputs.docker-image-name-with-tag }}
           labels: |
             env=${{ inputs.deploy-env }}
             type=${{ inputs.application-type }}          

--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -50,12 +50,11 @@ jobs:
       DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
       PRODUCTION_DEPLOYERS: ${{ secrets.PRODUCTION_DEPLOYERS }}
 
-  determine-image-name:
+  build-image-names:
     name: Determine Image Name
     runs-on: ubuntu-latest
-    outputs:
-      gchr-docker-image-name-with-tag: "${{ env.GCHR_DOCKER_IMAGE_NAME_WITH_TAG }}"
-      dockerhub-image-name-with-tag: "${{ env.DOCKERHUB_IMAGE_NAME_WITH_TAG }}"
+    outputs: 
+      names-with-tags: ${{ env.DOCKER_IMAGE_TAGS }}
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4.1.1
@@ -63,37 +62,32 @@ jobs:
           repository: 'clearlydefined/operations'
           ref: '3.1.0'
           path: 'operations'
-      - name: Determine gchr Image Name
-        id: determine_gchr_image_name
+      - name: Determine Image Name
+        id: determine_image_name
         run: |
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
-            "ghcr.io" \
-            "${{ github.repository }}" \
+            "${{ github.event.repository.name  }}" \
             "${{ inputs.deploy-env }}" \
             "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
-          echo "GCHR_DOCKER_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
-
-      - name: Determine Dockerhub Image Name
+          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
+      - name: Add ghcr.io 
+        id: add dockerhub image if required
+        run: |
+          echo "DOCKER_IMAGE_TAGS=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+      - name: Add Dockerhub if required
         if: ${{ inputs.docker-hub-username != '' }}
-        id: determine_dockerhub_name
+        id: add dockerhub image if required
         run: |
-          echo "BUILD_ARGS=${{ inputs.build-args }}"
-          script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
-            "${{ inputs.docker-hub-username }}" \
-            "${{ github.repository }}" \
-            "${{ inputs.deploy-env }}" \
-            "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
-          echo -e "---- script log\n$script_log\n----"; \
-          image_name=$(echo "$script_log" | tail -n 1)
-          echo "DOCKERHUB_IMAGE_NAME_WITH_TAG=$image_name" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_TAGS }},${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+
 
   build-docker-image:
     name: Build Image
     runs-on: ubuntu-latest
-    needs: [check-deployable, determine-image-name]
+    needs: [check-deployable, build-image-names]
     steps:
       - uses: actions/checkout@v4.1.1
 
@@ -123,8 +117,7 @@ jobs:
             BUILD_SHA=${{ github.sha }}
             ${{ inputs.build-args }}
           tags: |
-            ${{ needs.determine-image-name.outputs.gchr-docker-image-name-with-tag }}
-            ${{ needs.determine-image-name.outputs.dockerhub-image-name-with-tag }}
+            ${{ needs.build-image-names.outputs.names-with-tags }}
           labels: |
             env=${{ inputs.deploy-env }}
             type=${{ inputs.application-type }}          

--- a/.github/workflows/app-is-deployable.yml
+++ b/.github/workflows/app-is-deployable.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.0.0'
+          ref: 'v2.0.0'
           path: 'operations'
       - id: confirm-dev
         shell: bash
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.0.0'
+          ref: 'v2.0.0'
           path: 'operations'
 
       - name: Get organization ID

--- a/.github/workflows/app-is-deployable.yml
+++ b/.github/workflows/app-is-deployable.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.1.0'
           path: 'operations'
 
       - name: Get organization ID

--- a/.github/workflows/app-is-deployable.yml
+++ b/.github/workflows/app-is-deployable.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v2.0.0'
+          ref: 'v3.1.0'
           path: 'operations'
       - id: confirm-dev
         shell: bash
@@ -47,8 +47,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          # ref: 'v3.1.0'
-          ref: '73e1d7a7e30df3235db59a0eeafaa21c25784134'
+          ref: '3.1.0'
           path: 'operations'
 
       - name: Get organization ID

--- a/.github/workflows/app-is-deployable.yml
+++ b/.github/workflows/app-is-deployable.yml
@@ -47,7 +47,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: 'clearlydefined/operations'
-          ref: 'v3.1.0'
+          # ref: 'v3.1.0'
+          ref: '73e1d7a7e30df3235db59a0eeafaa21c25784134'
           path: 'operations'
 
       - name: Get organization ID

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -8,11 +8,12 @@
 # Outputs
 #   image_name_with_tag: the full image name with tag (e.g. ghcr.io/clearlydefined/service:v1.2.0)
 
-repo="$1"
-deploy_env="$2"
-image_tag="$3"
+image_base_name-dev = "$1"
+repo="$2"
+deploy_env="$3"
+image_tag="$4"
 
-image_base_name="ghcr.io/$repo" # e.g. ghcr.io/clearlydefined/service
+image_base_name="$image_base_name/$repo" # e.g. ghcr.io/clearlydefined/service
 if [[ "$deploy_env" == 'prod' ]] ; then
     image_name_with_tag="$image_base_name:$image_tag"
 elif [[ "$deploy_env" == 'dev' ]] ; then

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -17,13 +17,13 @@ image_tag="$4"
 image_base_name="$repo"
 
 # if gchr we need to include the path to GH repo
-if [[ "$registry" == 'ghcr.io' ]]; then
-  image_base_name="$registry/$repo" # e.g. ghcr.io/clearlydefined/service
+if [[ "$prefix" == 'ghcr.io' ]]; then
+  image_base_name="$prefix/$repo" # e.g. ghcr.io/clearlydefined/service
 fi
 
-if [[ "$registry" != 'ghcr.io' ]]; then
+if [[ "$prefix" != 'ghcr.io' ]]; then
   reponame="${repo#*/}"
-  image_base_name="$registry/$reponame" # e.g. <dockerhubuser>/service
+  image_base_name="$prefix/$reponame" # e.g. <dockerhubuser>/service
 fi
 
 if [[ "$deploy_env" == 'prod' ]] ; then

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 # Inputs
-#   $1 - repo: the orgname/reponame where the image will be published (e.g. 'clearlydefined/service')
-#   $2 - deploy_env: environment to deploy (i.e. dev | prod) - used as a label for the Docker image
-#   $3 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
+#   $1 - prefix: the registry prefix (e.g. ghcr.io or dockerhub user)
+#   $2 - repo: the orgname/reponame where the image will be published (e.g. 'clearlydefined/service')
+#   $3 - deploy_env: environment to deploy (i.e. dev | prod) - used as a label for the Docker image
+#   $4 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
 #
 # Outputs
 #   image_name_with_tag: the full image name with tag (e.g. ghcr.io/clearlydefined/service:v1.2.0)
 
-registry="$1"
+prefix="$1"
 repo="$2"
 deploy_env="$3"
 image_tag="$4"
 
 image_base_name="$repo"
+
+# if gchr we need to include the path to GH repo
 if [[ "$registry" == 'ghcr.io' ]]; then
   image_base_name="$registry/$repo" # e.g. ghcr.io/clearlydefined/service
 fi

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -18,6 +18,11 @@ if [[ "$registry" == 'ghcr.io' ]]; then
   image_base_name="$registry/$repo" # e.g. ghcr.io/clearlydefined/service
 fi
 
+if [[ "$registry" != 'ghcr.io' ]]; then
+  reponame="${repo#*/}"
+  image_base_name="$registry/$reponame" # e.g. <dockerhubuser>/service
+fi
+
 if [[ "$deploy_env" == 'prod' ]] ; then
     image_name_with_tag="$image_base_name:$image_tag"
 elif [[ "$deploy_env" == 'dev' ]] ; then

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -8,12 +8,16 @@
 # Outputs
 #   image_name_with_tag: the full image name with tag (e.g. ghcr.io/clearlydefined/service:v1.2.0)
 
-image_base_name-dev = "$1"
+registry="$1"
 repo="$2"
 deploy_env="$3"
 image_tag="$4"
 
-image_base_name="$image_base_name/$repo" # e.g. ghcr.io/clearlydefined/service
+image_base_name="$repo"
+if [[ "$registry" == 'ghcr.io' ]]; then
+  image_base_name="$registry/$repo" # e.g. ghcr.io/clearlydefined/service
+fi
+
 if [[ "$deploy_env" == 'prod' ]] ; then
     image_name_with_tag="$image_base_name:$image_tag"
 elif [[ "$deploy_env" == 'dev' ]] ; then

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -1,35 +1,22 @@
 #!/bin/bash
 
 # Inputs
-#   $1 - prefix: the registry prefix (e.g. ghcr.io or dockerhub user)
-#   $2 - repo: the orgname/reponame where the image will be published (e.g. 'clearlydefined/service')
-#   $3 - deploy_env: environment to deploy (i.e. dev | prod) - used as a label for the Docker image
-#   $4 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
+#   $1 - repo_name: the reponame where the image will be published (e.g. 'service')
+#   $2 - deploy_env: environment to deploy (i.e. dev | prod) - used as a label for the Docker image
+#   $3 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
 #
 # Outputs
 #   image_name_with_tag: the full image name with tag (e.g. ghcr.io/clearlydefined/service:v1.2.0)
 
-prefix="$1"
-repo="$2"
-deploy_env="$3"
-image_tag="$4"
+repo_name="$1"
+deploy_env="$2"
+image_tag="$3"
 
-image_base_name="$repo"
-
-# if gchr we need to include the path to GH repo
-if [[ "$prefix" == 'ghcr.io' ]]; then
-  image_base_name="$prefix/$repo" # e.g. ghcr.io/clearlydefined/service
-fi
-
-if [[ "$prefix" != 'ghcr.io' ]]; then
-  reponame="${repo#*/}"
-  image_base_name="$prefix/$reponame" # e.g. <dockerhubuser>/service
-fi
-
+image_name_with_tag=""
 if [[ "$deploy_env" == 'prod' ]] ; then
-    image_name_with_tag="$image_base_name:$image_tag"
+    image_name_with_tag="$repo_name:$image_tag"
 elif [[ "$deploy_env" == 'dev' ]] ; then
-    image_name_with_tag="$image_base_name-dev:$image_tag"
+    image_name_with_tag="$repo_name-dev:$image_tag"
 else
     echo "ERROR: Invalid deploy environment: $deploy_env. Must be 'dev' or 'prod'"
     exit 1

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -6,7 +6,7 @@
 #   $3 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
 #
 # Outputs
-#   image_name_with_tag: the full image name with tag (e.g. ghcr.io/clearlydefined/service:v1.2.0)
+#   image_name_with_tag: the full image name with tag (e.g. service:v1.2.0, service-dev:v1.2.0+dev:1D3F567890)
 
 repo_name="$1"
 deploy_env="$2"

--- a/tests/scripts/app-workflows/test-determine-image-name.bats
+++ b/tests/scripts/app-workflows/test-determine-image-name.bats
@@ -3,21 +3,21 @@
 load 'test_helpers'
 
 @test "deploy to dev environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-org/test-repo dev test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo dev test-tag
   test_value 0 "$status"
-  test_value "determine_image_name -> outputs -> image_name_with_tag: ghcr.io/test-org/test-repo-dev:test-tag" "${lines[0]}"
-  test_value ghcr.io/test-org/test-repo-dev:test-tag "${lines[1]}"
+  test_value "determine_image_name -> outputs -> image_name_with_tag: test-repo-dev:test-tag" "${lines[0]}"
+  test_value test-repo-dev:test-tag "${lines[1]}"
 }
 
 @test "deploy to prod environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-org/test-repo prod test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo prod test-tag
   test_value 0 "$status"
-  test_value "determine_image_name -> outputs -> image_name_with_tag: ghcr.io/test-org/test-repo:test-tag" "${lines[0]}"
-  test_value ghcr.io/test-org/test-repo:test-tag "${lines[1]}"
+  test_value "determine_image_name -> outputs -> image_name_with_tag: test-repo:test-tag" "${lines[0]}"
+  test_value test-repo:test-tag "${lines[1]}"
 }
 
 @test "invalid deploy environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-org/test-repo BAD_ENV test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo BAD_ENV test-tag
   test_value 1 "$status"
   test_value "ERROR: Invalid deploy environment: BAD_ENV. Must be 'dev' or 'prod'" "${lines[0]}"
 }


### PR DESCRIPTION
# What

To migrate deployment of Production Crawler to CD Azure from Microsoft owned Azure.
Changes to workflow `app-build-and-deploy`

This PR enables the optional docker image publish to Docker Hub, conditional on providing
- Input `docker-hub-username` 
- secret `DOCKERHUB_TOKEN`

Without these the action only deploys to ghcr

# Why

- Unlocks ability to have production crawlers in Cd Azure means any member of Clearly Defined with access to the account can manage, support and troubleshoot. Currently we need to request help from MSFT if there are any issues.
- Our other App Services the api and website are already using ghcr for images so we need to move crawler there as well
- MSFT crawlers are deployed using webhook from dockerhub that triggers the deploy. So we still need to publish to dockerhub.

# Testing

Using test branch https://github.com/clearlydefined/crawler/tree/deploy-production-cd-azure
connfigured to publish to my dockerhub, and deploy to a inactive prod crawler in CD azure

Successful prod deploy which publshses 2 images docker hub and ghcr: https://github.com/clearlydefined/crawler/actions/runs/11163856034
Sucessful dev deploy that publishes 1 gchr image https://github.com/clearlydefined/crawler/actions/runs/11164059253

# notes:

I will squash the commits when I merge as there was a lot of back and forth to test
