### PR TITLE
Control integration tests with input

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,6 +3,15 @@ name: Integration Test
 on:
   workflow_dispatch:
     inputs:
+      runType:
+        type: choice
+        description: To run tests with dynamic or fixed coordinates or both
+        options:
+        - dynamic
+        - fixed
+        - all
+        required: true
+
       baseFolderPath:
         description: 'Base folder path for diffs'
         required: true
@@ -16,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
-      matrix:
-        dynamicCoordinates: [true, false]
     defaults:
       run:
         working-directory: ./tools/integration
@@ -37,10 +44,12 @@ jobs:
         run: npm test
         
       - name: Trigger harvest and verify completion
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
+        if: ${{ inputs.runType == 'dynamic' || 'all' }}
+        run: DYNAMIC_COORDINATES=true npm run e2e-test-harvest
 
       - name: Verify service functions
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
+        if: ${{ inputs.runType == 'fixed' || 'all' }}
+        run: DYNAMIC_COORDINATES=false npm run e2e-test-service
 
       - name: Generate structured diffs
         run: npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}


### PR DESCRIPTION
So that we can control Integration tests.

Choose to run with dynamic fixtures, fixed fixtures, or both