### PR TITLE
Use user input to drive integration tests action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,19 +3,14 @@ name: Integration Test
 on:
   workflow_dispatch:
     inputs:
-      runType:
-        type: choice
-        description: To run tests with dynamic or fixed coordinates or both
-        options:
-        - dynamic
-        - fixed
-        - all
-        required: true
-
       baseFolderPath:
         description: 'Base folder path for diffs'
         required: true
         default: 'diffs'
+      dynamicCoordinates:
+        description: 'Array of booleans for dynamic coordinates (e.g., [true, false])'
+        required: true
+        default: '[true, false]'
 
 permissions:
   contents: read
@@ -25,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
+      matrix:
+        dynamicCoordinates: ${{ fromJson(github.event.inputs.dynamicCoordinates) }}
     defaults:
       run:
         working-directory: ./tools/integration
@@ -44,12 +41,10 @@ jobs:
         run: npm test
         
       - name: Trigger harvest and verify completion
-        if: ${{ inputs.runType == 'dynamic' || 'all' }}
-        run: DYNAMIC_COORDINATES=true npm run e2e-test-harvest
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
       - name: Verify service functions
-        if: ${{ inputs.runType == 'fixed' || 'all' }}
-        run: DYNAMIC_COORDINATES=false npm run e2e-test-service
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
 
       - name: Generate structured diffs
         run: npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,4 +53,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: diffs-${{ matrix.dynamicCoordinates == 'true' && 'dynamic' || 'static' }}
-          path: ${{ github.event.inputs.baseFolderPath }}
+          path: ./tools/integration/${{ github.event.inputs.baseFolderPath }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,6 +44,8 @@ jobs:
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
       - name: Verify service functions
+        id: verify-service-functions
+        continue-on-error: true
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
 
       - name: Generate structured diffs
@@ -54,3 +56,7 @@ jobs:
         with:
           name: diffs-${{ matrix.dynamicCoordinates == 'true' && 'dynamic' || 'static' }}
           path: ./tools/integration/${{ github.event.inputs.baseFolderPath }}
+
+      - name: Mark build status
+        if: steps.verify-service-functions.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,7 +49,7 @@ jobs:
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
 
       - name: Generate structured diffs
-        run: npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}
 
       - name: Upload diffs artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
https://github.com/clearlydefined/operations/pull/102 has broken the integration test action logic. This change is to restore it, while still keeping the flavour of integration tests to run user-configurable.