### PR TITLE
Fix integration tests

### DIFF
--- a/tools/integration/test/integration/e2e-test-service/attachmentTest.js
+++ b/tools/integration/test/integration/e2e-test-service/attachmentTest.js
@@ -5,17 +5,19 @@ const { callFetch } = require('../../../lib/fetch')
 const { devApiBaseUrl, prodApiBaseUrl, getComponents, definition } = require('../testConfig')
 const { strictEqual } = require('assert')
 
-describe('Validation attachments between dev and prod', async function () {
-  this.timeout(definition.timeout * 2)
-
-  //Rest a bit to avoid overloading the servers
-  afterEach(() => new Promise(resolve => setTimeout(resolve, definition.timeout / 2)))
-
+;(async function () {
   const components = await getComponents()
-  components.forEach(coordinates => {
-    it(`should have the same attachement as prod for ${coordinates}`, () => fetchAndCompareAttachments(coordinates))
+  describe('Validation attachments between dev and prod', async function () {
+    this.timeout(definition.timeout * 2)
+
+    //Rest a bit to avoid overloading the servers
+    afterEach(() => new Promise(resolve => setTimeout(resolve, definition.timeout / 2)))
+
+    components.forEach(coordinates => {
+      it(`should have the same attachement as prod for ${coordinates}`, () => fetchAndCompareAttachments(coordinates))
+    })
   })
-})
+})()
 
 async function fetchAndCompareAttachments(coordinates) {
   const expectedAttachments = await findAttachments(prodApiBaseUrl, coordinates)

--- a/tools/integration/test/integration/e2e-test-service/noticeTest.js
+++ b/tools/integration/test/integration/e2e-test-service/noticeTest.js
@@ -7,24 +7,26 @@ const { devApiBaseUrl, prodApiBaseUrl, getComponents, definition } = require('..
 const nock = require('nock')
 const fs = require('fs')
 
-describe('Validate notice files between dev and prod', async function () {
-  this.timeout(definition.timeout)
+;(async function () {
+  const components = await getComponents()
+  describe('Validate notice files between dev and prod', async function () {
+    this.timeout(definition.timeout)
 
-  //Rest a bit to avoid overloading the servers
-  afterEach(() => new Promise(resolve => setTimeout(resolve, definition.timeout / 2)))
+    //Rest a bit to avoid overloading the servers
+    afterEach(() => new Promise(resolve => setTimeout(resolve, definition.timeout / 2)))
 
-  before(() => {
-    loadFixtures().forEach(([coordinatesString, notice]) => {
-      nock(prodApiBaseUrl, { allowUnmocked: true })
-        .post('/notices', { coordinates: [coordinatesString] })
-        .reply(200, notice)
+    before(() => {
+      loadFixtures().forEach(([coordinatesString, notice]) => {
+        nock(prodApiBaseUrl, { allowUnmocked: true })
+          .post('/notices', { coordinates: [coordinatesString] })
+          .reply(200, notice)
+      })
+    })
+    components.forEach(coordinates => {
+      it(`should return the same notice as prod for ${coordinates}`, () => fetchAndCompareNotices(coordinates))
     })
   })
-  const components = await getComponents()
-  components.forEach(coordinates => {
-    it(`should return the same notice as prod for ${coordinates}`, () => fetchAndCompareNotices(coordinates))
-  })
-})
+})()
 
 async function fetchAndCompareNotices(coordinates) {
   const [computedNotice, expectedNotice] = await Promise.all(


### PR DESCRIPTION
Integration tests running over a list of components are being skipped.  The reason is that the callbacks in `describe()` must be synchronous.  See documentation at https://github.com/mochajs/mocha/pull/5046/files and detailed explanation at https://github.com/mochajs/mocha/issues/2975#issuecomment-1004176440.

Adapted the affected tests accordingly. Changes are mainly wrapping the mocha describe into a top level async function. 

The log of a test run can be found [here](https://github.com/qtomlinson/operations/actions/runs/11535407563/job/32110446531).  