### PR TITLE
for docker hub image, include latest tag

### DIFF
--- a/.github/workflows/app-build-docker-image.yml
+++ b/.github/workflows/app-build-docker-image.yml
@@ -69,23 +69,23 @@ jobs:
           echo "BUILD_ARGS=${{ inputs.build-args }}"
           script_log=$(./operations/scripts/app-workflows/determine-image-name.sh \
             "${{ github.event.repository.name  }}" \
-            "${{ inputs.deploy-env }}" \
-            "${{ inputs.application-version }}") || (echo "$script_log" && exit 1)
+            "${{ inputs.deploy-env }}") || (echo "$script_log" && exit 1)
           echo -e "---- script log\n$script_log\n----"; \
           image_name=$(echo "$script_log" | tail -n 1)
           echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
       - name: Add ghcr.io 
         id: add-ghcr
         run: |
-          ghcr_image_tags="ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}"
+          ghcr_image_tags="ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ inputs.application-version }}"
           echo "DOCKER_IMAGE_TAGS=$ghcr_image_tags" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_TO_USE=$ghcr_image_tags" >> $GITHUB_ENV
       - name: add-dockerhub
         if: ${{ inputs.docker-hub-username != '' }}
         id: add-dockerhub
         run: |
-          docker_image_tags="${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}"
-          echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_IMAGE_TAGS }}, $docker_image_tags" >> $GITHUB_ENV
+          docker_image_tag="${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}:${{ inputs.application-version }}"
+          latest_image_tag="${{ inputs.docker-hub-username }}/${{ env.IMAGE_NAME }}:latest"
+          echo "DOCKER_IMAGE_TAGS=${{ env.DOCKER_IMAGE_TAGS }}, $docker_image_tag, $latest_image_tag" >> $GITHUB_ENV
           # use Docker Hub image if it is created by overwriting DOCKER_IMAGE_TO_USE
           echo "DOCKER_IMAGE_TO_USE=$docker_image_tags" >> $GITHUB_ENV
 

--- a/scripts/app-workflows/determine-image-name.sh
+++ b/scripts/app-workflows/determine-image-name.sh
@@ -3,24 +3,22 @@
 # Inputs
 #   $1 - repo_name: the reponame where the image will be published (e.g. 'service')
 #   $2 - deploy_env: environment to deploy (i.e. dev | prod) - used as a label for the Docker image
-#   $3 - image-tag: the tag to use for the image (e.g. prod: v1.2.0, dev: v1.2.0+dev:1D3F567890)
 #
 # Outputs
-#   image_name_with_tag: the full image name with tag (e.g. service:v1.2.0, service-dev:v1.2.0+dev:1D3F567890)
+#   image_name: the image name without tags (e.g. service, service-dev)
 
 repo_name="$1"
 deploy_env="$2"
-image_tag="$3"
 
-image_name_with_tag=""
+image_name=""
 if [[ "$deploy_env" == 'prod' ]] ; then
-    image_name_with_tag="$repo_name:$image_tag"
+    image_name="$repo_name"
 elif [[ "$deploy_env" == 'dev' ]] ; then
-    image_name_with_tag="$repo_name-dev:$image_tag"
+    image_name="$repo_name-dev"
 else
     echo "ERROR: Invalid deploy environment: $deploy_env. Must be 'dev' or 'prod'"
     exit 1
 fi
 
-echo "determine_image_name -> outputs -> image_name_with_tag: $image_name_with_tag"
-echo "$image_name_with_tag"
+echo "determine_image_name -> outputs -> image_name: $image_name"
+echo "$image_name"

--- a/tests/scripts/app-workflows/test-determine-image-name.bats
+++ b/tests/scripts/app-workflows/test-determine-image-name.bats
@@ -3,21 +3,21 @@
 load 'test_helpers'
 
 @test "deploy to dev environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-repo dev test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo dev
   test_value 0 "$status"
-  test_value "determine_image_name -> outputs -> image_name_with_tag: test-repo-dev:test-tag" "${lines[0]}"
-  test_value test-repo-dev:test-tag "${lines[1]}"
+  test_value "determine_image_name -> outputs -> image_name: test-repo-dev" "${lines[0]}"
+  test_value test-repo-dev "${lines[1]}"
 }
 
 @test "deploy to prod environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-repo prod test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo prod
   test_value 0 "$status"
-  test_value "determine_image_name -> outputs -> image_name_with_tag: test-repo:test-tag" "${lines[0]}"
-  test_value test-repo:test-tag "${lines[1]}"
+  test_value "determine_image_name -> outputs -> image_name: test-repo" "${lines[0]}"
+  test_value test-repo "${lines[1]}"
 }
 
 @test "invalid deploy environment" {
-  run ./scripts/app-workflows/determine-image-name.sh test-repo BAD_ENV test-tag
+  run ./scripts/app-workflows/determine-image-name.sh test-repo BAD_ENV
   test_value 1 "$status"
   test_value "ERROR: Invalid deploy environment: BAD_ENV. Must be 'dev' or 'prod'" "${lines[0]}"
 }


### PR DESCRIPTION
### Description

Fix the crawler prod image not updating on deploy.  This was caused by the current production crawlers use of the latest tag in Docker Hub to get the image to use and the deploy process through GH workflow not creating that tag.

### Expected

On release of crawler prod, the deploy should update the production crawlers to the new release version.

### Actual

On release of crawler prod, the deploy has no effect on the production crawlers.

### Fix

Update the GH workflow process to create the `latest` tag in Docker Hub. The prod crawlers will be triggered to grab the new latest image and restart.

### Testing

* in test branch, updated crawler-dev deploy to add docker credentials to my docker hub
* ran deploy dev on the test branch
* confirmed that the version and latest tags were created in my docker hub

### Follow-on

Update refs to this workflow to a new release version of operations that includes this PR.  And then cut a release at that version that includes this and the PR that updates the version.

CC: @ljones140 
