### PR TITLE
Run the entire end to end test suite in integration test

### DIFF
--- a/.github/workflows/integration-test-custom.yml
+++ b/.github/workflows/integration-test-custom.yml
@@ -214,10 +214,10 @@ jobs:
       - name: Trigger harvest and verify completion
         run: DEV_API_BASE_URL=${{ env.DEV_API_BASE_URL }} DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
-      - name: Verify service functions
+      - name: Verify definition tests
         id: verify-service-functions
         continue-on-error: true
-        run: DEV_API_BASE_URL=${{ env.DEV_API_BASE_URL }} DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
+        run: DEV_API_BASE_URL=${{ env.DEV_API_BASE_URL }} DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-definition
 
       - name: Generate structured diffs
         run: DEV_API_BASE_URL=${{ env.DEV_API_BASE_URL }} DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm test
         
       - name: Trigger harvest and verify completion if required
-        if: github.event.inputs.skipHarvest == 'false'
+        if: github.event.inputs.skipHarvest == 'false' || matrix.dynamicCoordinates == 'true'
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
       - name: Verify service functions

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,6 +11,10 @@ on:
         description: 'Array of booleans for dynamic coordinates (e.g., [true, false])'
         required: true
         default: '[true, false]'
+      skipHarvest:
+        description: "Skip harvest and verify completion"
+        required: false
+        default: 'false'
 
 permissions:
   contents: read
@@ -40,13 +44,14 @@ jobs:
       - name: Run tests on tools
         run: npm test
         
-      - name: Trigger harvest and verify completion
+      - name: Trigger harvest and verify completion if required
+        if: github.event.inputs.skipHarvest == 'false'
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
       - name: Verify service functions
         id: verify-service-functions
         continue-on-error: true
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-definition
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
 
       - name: Generate structured diffs
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}

--- a/tools/integration/test/integration/testConfig.js
+++ b/tools/integration/test/integration/testConfig.js
@@ -86,6 +86,6 @@ module.exports = {
     timeout: 1000 * 60 * 60 * 4 // 4 hours for harvesting all the components
   },
   definition: {
-    timeout: 1000 * 10 // for each component
+    timeout: 1000 * 60 // for each component
   }
 }


### PR DESCRIPTION
Run definition tests in integration testing on the custom infra structure.
Also add the option of skipping harvest for static components as the harvest can take quite some time.