### PR TITLE
Document environment variables for logging node heap stats

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -356,6 +356,8 @@ The environmental variables for the clearlydefined-api-dev App Service include:
 * HARVEST_QUEUE_PREFIX
 * HARVEST_QUEUE_PROVIDER
 * HARVESTER_PROVIDER
+* LOG_NODE_HEAPSTATS
+* LOG_NODE_HEAPSTATS_INTERVAL_MS
 * NODE_ENV
 * RATE_LIMIT_MAX
 * RATE_LIMIT_WINDOW
@@ -534,6 +536,22 @@ This is the prefix we use for queues that we use for harvesting. In this case, i
 **HARVESTER_PROVIDER**
 
 This indicates what type of service we use for harvesting, in this case it's **crawlerQueue**, which corresponds with the [crawlerQueue harvest provider](https://github.com/clearlydefined/service/blob/master/providers/harvest/crawlerQueue.js)
+
+**LOG_NODE_HEAPSTATS**
+This is an optional flag to `enable` logging of Node's `v8` module's memory usage data using the `getHeapSpaceStatistics` and `getHeapStatistics()` functions.
+
+Value is either `true` or `false`
+> Note: if this env var is not present, it equates to `false`
+
+- [Node.js v8 engine docs - getHeapSpaceStatistics()](https://nodejs.org/docs/v22.12.0/api/v8.html#v8getheapspacestatistics)
+
+- [Node.js v8 engine docs - getHeapStatistics()](https://nodejs.org/docs/v22.12.0/api/v8.html#v8getheapstatistics)
+
+**LOG_NODE_HEAPSTATS_INTERVAL_MS**
+
+This is an optional environment variable that sets the interval to log heap statistics (When enabled). This is a number in `ms` (`milliseconds`).
+
+> NOTE: The default value is `30,000 ms` (`30 seconds`)
 
 **MULTIVERSION_CURATION_FF**
 

--- a/overview.md
+++ b/overview.md
@@ -543,15 +543,22 @@ This is an optional flag to `enable` logging of Node's `v8` module's memory usag
 Value is either `true` or `false`
 > Note: if this env var is not present, it equates to `false`
 
+> example:  
+> `LOG_NODE_HEAPSTATS` = `true`
+
 - [Node.js v8 engine docs - getHeapSpaceStatistics()](https://nodejs.org/docs/v22.12.0/api/v8.html#v8getheapspacestatistics)
 
 - [Node.js v8 engine docs - getHeapStatistics()](https://nodejs.org/docs/v22.12.0/api/v8.html#v8getheapstatistics)
 
 **LOG_NODE_HEAPSTATS_INTERVAL_MS**
 
-This is an optional environment variable that sets the interval to log heap statistics (When enabled). This is a number in `ms` (`milliseconds`).
+This is an optional environment variable that sets the interval to log heap statistics (When enabled).
 
-> NOTE: The default value is `30,000 ms` (`30 seconds`)
+Value is a number in `ms` (`milliseconds`).
+> NOTE: The default value is `30000` ms (`30` seconds)
+
+> example:   
+> `LOG_NODE_HEAPSTATS_INTERVAL_MS` = `10000`
 
 **MULTIVERSION_CURATION_FF**
 


### PR DESCRIPTION
This PR is related to the following PR that adds conditional heap memory statistics logging:
https://github.com/clearlydefined/service/pull/1238

The related PR adds 2 additional environment variables to configure the behavior of this logging:
- `LOG_NODE_HEAPSTATS`  (flag to enable/disable heap stats logging)
- `LOG_NODE_HEAPSTATS_INTERVAL_MS`  (number representing the interval (in milliseconds) to log heap stats at)

This PR adds these 2 new environment variables and their descriptions to the master document for documentation purposes.