### PR TITLE
Configure scheduled execution for end-to-end integration test suite

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,10 +11,12 @@ on:
         description: 'Array of booleans for dynamic coordinates (e.g., [true, false])'
         required: true
         default: '[true, false]'
-      skipHarvest:
-        description: "Skip harvest and verify completion"
+      doHarvest:
+        description: "Do harvest and verify completion"
         required: false
-        default: 'false'
+        default: 'true'
+  schedule:
+    - cron: '0 0 * * 6' # Every Saturday at midnight
 
 permissions:
   contents: read
@@ -25,7 +27,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        dynamicCoordinates: ${{ fromJson(github.event.inputs.dynamicCoordinates) }}
+        dynamicCoordinates: ${{ fromJson(github.event.inputs.dynamicCoordinates || '[false]') }}
     defaults:
       run:
         working-directory: ./tools/integration
@@ -45,7 +47,7 @@ jobs:
         run: npm test
         
       - name: Trigger harvest and verify completion if required
-        if: github.event.inputs.skipHarvest == 'false' || matrix.dynamicCoordinates == 'true'
+        if: github.event.inputs.doHarvest == 'true' || github.event.inputs.doHarvest == null || matrix.dynamicCoordinates == 'true'
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-harvest
 
       - name: Verify service functions
@@ -54,13 +56,13 @@ jobs:
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
 
       - name: Generate structured diffs
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath || 'diffs' }}
 
       - name: Upload diffs artifact
         uses: actions/upload-artifact@v4
         with:
           name: diffs-${{ matrix.dynamicCoordinates == 'true' && 'dynamic' || 'static' }}
-          path: ./tools/integration/${{ github.event.inputs.baseFolderPath }}
+          path: ./tools/integration/${{ github.event.inputs.baseFolderPath || 'diffs' }}
 
       - name: Mark build status
         if: steps.verify-service-functions.outcome == 'failure'


### PR DESCRIPTION
The log for the abbreviated run is available at https://github.com/qtomlinson/operations/actions/runs/14767228124/job/41460965345. This run, triggered by a push event, executes the definition tests for only two components