### PR TITLE
Add cleanup for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Verify service functions
         id: verify-service-functions
         continue-on-error: true
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run e2e-test-service
 
       - name: Generate structured diffs
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Verify service functions
         id: verify-service-functions
         continue-on-error: true
-        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run e2e-test-service
+        run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run e2e-test-service
+
+      - name: Clean up
+        run: GITHUB_TOKEN=${{ secrets.CLEARLYDEFINED_GITHUB_PAT }} npm run e2e-test-service-cleanup
 
       - name: Generate structured diffs
         run: DYNAMIC_COORDINATES=${{ matrix.dynamicCoordinates }} npm run definitions-diff ${{ github.event.inputs.baseFolderPath }}

--- a/tools/integration/lib/cleanupPR.js
+++ b/tools/integration/lib/cleanupPR.js
@@ -1,13 +1,26 @@
 // (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+/** @type {string | undefined} */
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+
+/** @type {string} */
 const REPO_OWNER = 'clearlydefined'
+
+/** @type {string} */
 const REPO_NAME = 'curated-data-dev'
 
+/** @type {string} */
 const TARGET_TITLE = 'test maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16'
+
+/** @type {string} */
 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 
+/**
+ * Creates an authenticated Octokit instance.
+ * @returns {Promise<import('@octokit/rest').Octokit>}
+ * @throws {Error} If GITHUB_TOKEN is not set.
+ */
 const createOctokit = () =>
   import('@octokit/rest').then(({ Octokit }) => {
     if (!GITHUB_TOKEN) {
@@ -18,7 +31,15 @@ const createOctokit = () =>
     })
   })
 
+/**
+ * Finds pull requests matching the given title and created before the specified date.
+ * @param {import('@octokit/rest').Octokit} octokit - The Octokit instance.
+ * @param {string} givenTitle - The title to search for.
+ * @param {string} dateSince - The ISO date string to filter PRs created before this date.
+ * @returns {Promise<{prNumber: number, prTitle: string}[]>} The list of matching pull requests.
+ */
 const findPullRequests = async (octokit, givenTitle, dateSince) => {
+  /** @type {{prNumber: number, prTitle: string}[]} */
   const result = []
   try {
     const iterator = octokit.paginate.iterator(octokit.rest.pulls.list, {
@@ -36,11 +57,18 @@ const findPullRequests = async (octokit, givenTitle, dateSince) => {
     }
     return result
   } catch (error) {
-    console.error(`Failed to fetch pull requests for repo ${REPO_OWNER}/${REPO_NAME}: ${error.message}`)
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    console.error(`Failed to fetch pull requests for repo ${REPO_OWNER}/${REPO_NAME}: ${errorMessage}`)
     throw error
   }
 }
 
+/**
+ * Filters pull requests by title.
+ * @param {{number: number, title: string}[]} openPrs - The list of open pull requests.
+ * @param {string} givenTitle - The title to search for.
+ * @returns {{prNumber: number, prTitle: string}[]} The list of matching pull requests.
+ */
 const findInBatch = (openPrs, givenTitle) => {
   const found = (openPrs || [])
     .map(({ number, title }) => {
@@ -53,6 +81,12 @@ const findInBatch = (openPrs, givenTitle) => {
   return found
 }
 
+/**
+ * Checks if the iteration is done based on the date of the earliest PR.
+ * @param {{created_at: string}[]} prsByDateDesc - The list of PRs sorted by date in descending order.
+ * @param {string} dateSince - The ISO date string to compare against.
+ * @returns {boolean} True if the iteration is done, false otherwise.
+ */
 const checkIsDone = (prsByDateDesc, dateSince) => {
   if (!prsByDateDesc.length) return true
   const earliestPr = prsByDateDesc[prsByDateDesc.length - 1]
@@ -60,7 +94,13 @@ const checkIsDone = (prsByDateDesc, dateSince) => {
   return earliestPr.created_at < dateSince
 }
 
-// Function to close a pull request
+/**
+ * Closes a pull request.
+ * @param {import('@octokit/rest').Octokit} octokit - The Octokit instance.
+ * @param {number} prNumber - The pull request number.
+ * @returns {Promise<void>}
+ * @throws {Error} If the pull request cannot be closed.
+ */
 const closePullRequest = async (octokit, prNumber) => {
   try {
     await octokit.pulls.update({
@@ -71,11 +111,17 @@ const closePullRequest = async (octokit, prNumber) => {
     })
     console.info(`PR #${prNumber} closed successfully.`)
   } catch (error) {
-    console.error(`Failed to close PR #${prNumber}: ${error.message}`)
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    console.error(`Failed to close PR #${prNumber}: ${errorMessage}`)
     throw error
   }
 }
 
+/**
+ * Cleans up pull requests with the specified title created before the given date.
+ * @param {string} [dateSince=oneDayAgo] - The ISO date string to filter PRs created before this date.
+ * @returns {Promise<void>}
+ */
 const cleanup = async (dateSince = oneDayAgo) => {
   console.info(`Owner: ${REPO_OWNER}, Repo: ${REPO_NAME}`)
   console.info(`Searching for PRs with title: ${TARGET_TITLE}`)

--- a/tools/integration/lib/cleanupPR.js
+++ b/tools/integration/lib/cleanupPR.js
@@ -1,0 +1,95 @@
+// (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const REPO_OWNER = 'clearlydefined'
+const REPO_NAME = 'curated-data-dev'
+
+const TARGET_TITLE = 'test maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16'
+const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+const createOctokit = () =>
+  import('@octokit/rest').then(({ Octokit }) => {
+    if (!GITHUB_TOKEN) {
+      throw new Error('GITHUB_TOKEN is not set')
+    }
+    return new Octokit({
+      auth: GITHUB_TOKEN
+    })
+  })
+
+const findPullRequests = async (octokit, givenTitle, dateSince) => {
+  const result = []
+  try {
+    const iterator = octokit.paginate.iterator(octokit.rest.pulls.list, {
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      state: 'open',
+      sort: 'created',
+      direction: 'desc'
+    })
+
+    for await (const { data: openPrs } of iterator) {
+      const foundPrs = findInBatch(openPrs, givenTitle)
+      result.push(...foundPrs)
+      if (checkIsDone(openPrs, dateSince)) break
+    }
+    return result
+  } catch (error) {
+    console.error(`Failed to fetch pull requests for repo ${REPO_OWNER}/${REPO_NAME}: ${error.message}`)
+    throw error
+  }
+}
+
+const findInBatch = (openPrs, givenTitle) => {
+  const found = (openPrs || [])
+    .map(({ number, title }) => {
+      console.debug(`Checking PR #${number}: ${title}`)
+      return { prNumber: number, prTitle: title }
+    })
+    .filter(({ prTitle }) => prTitle === givenTitle)
+
+  console.info(`Found ${found.length} PRs with title: ${givenTitle}`)
+  return found
+}
+
+const checkIsDone = (prsByDateDesc, dateSince) => {
+  if (!prsByDateDesc.length) return true
+  const earliestPr = prsByDateDesc[prsByDateDesc.length - 1]
+  console.debug(`${earliestPr.created_at} < ${dateSince} ?`)
+  return earliestPr.created_at < dateSince
+}
+
+// Function to close a pull request
+const closePullRequest = async (octokit, prNumber) => {
+  try {
+    await octokit.pulls.update({
+      owner: REPO_OWNER,
+      repo: REPO_NAME,
+      pull_number: prNumber,
+      state: 'closed'
+    })
+    console.info(`PR #${prNumber} closed successfully.`)
+  } catch (error) {
+    console.error(`Failed to close PR #${prNumber}: ${error.message}`)
+    throw error
+  }
+}
+
+const cleanup = async (dateSince = oneDayAgo) => {
+  console.info(`Owner: ${REPO_OWNER}, Repo: ${REPO_NAME}`)
+  console.info(`Searching for PRs with title: ${TARGET_TITLE}`)
+
+  const octokit = await createOctokit()
+  const found = await findPullRequests(octokit, TARGET_TITLE, dateSince)
+  console.info(`Found ${found.length} PRs with title: ${TARGET_TITLE} before ${dateSince}`)
+
+  for (const { prTitle, prNumber } of found) {
+    console.debug(`Found PR #${prNumber} with title: ${prTitle}`)
+    await closePullRequest(octokit, prNumber)
+  }
+}
+
+cleanup()
+  .then(() => console.log('Cleanup completed.'))
+  .catch(error => console.error(`Error during cleanup: ${error.message}`))

--- a/tools/integration/package-lock.json
+++ b/tools/integration/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/rest": "^21.1.1",
         "async-retry": "^1.3.3"
       },
       "devDependencies": {
@@ -153,6 +154,174 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
+      "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.0.0.tgz",
+      "integrity": "sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
+      "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.0.0.tgz",
+      "integrity": "sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -307,6 +476,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -715,6 +889,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1837,6 +2026,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/tools/integration/package-lock.json
+++ b/tools/integration/package-lock.json
@@ -13,6 +13,8 @@
         "async-retry": "^1.3.3"
       },
       "devDependencies": {
+        "@octokit/types": "^14.0.0",
+        "@types/node": "^22.15.5",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "lodash": "^4.17.21",
@@ -20,7 +22,8 @@
         "nock": "^13.5.4",
         "node-fetch": "^3.3.2",
         "prettier": "^3.2.5",
-        "sinon": "^17.0.1"
+        "sinon": "^17.0.1",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -367,6 +370,15 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -2026,6 +2038,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.2",

--- a/tools/integration/package.json
+++ b/tools/integration/package.json
@@ -6,7 +6,7 @@
     "test": "npm run mocha && npm run lint",
     "e2e-test-harvest": "mocha test/integration/harvestTest.js",
     "e2e-test-service": "mocha --exit \"test/integration/e2e-test-service/**/*.js\"",
-    "e2e-test-service-cleanup": "node ./lib/cleanupPR.js",
+    "e2e-test-service-cleanup": "node ./test/integration/cleanup.js",
     "e2e-test-definition": "mocha --exit \"test/integration/e2e-test-service/definitionTest.js\"",
     "mocha": "mocha --exit \"test/lib/**/*.js\"",
     "lint": "npm run prettier:check && npm run eslint",

--- a/tools/integration/package.json
+++ b/tools/integration/package.json
@@ -6,7 +6,7 @@
     "test": "npm run mocha && npm run lint",
     "e2e-test-harvest": "mocha test/integration/harvestTest.js",
     "e2e-test-service": "mocha --exit \"test/integration/e2e-test-service/**/*.js\"",
-    "poste2e-test-service": "node ./lib/cleanupPR.js",
+    "e2e-test-service-cleanup": "node ./lib/cleanupPR.js",
     "e2e-test-definition": "mocha --exit \"test/integration/e2e-test-service/definitionTest.js\"",
     "mocha": "mocha --exit \"test/lib/**/*.js\"",
     "lint": "npm run prettier:check && npm run eslint",
@@ -20,6 +20,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@octokit/types": "^14.0.0",
+    "@types/node": "^22.15.5",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "lodash": "^4.17.21",
@@ -27,7 +29,8 @@
     "nock": "^13.5.4",
     "node-fetch": "^3.3.2",
     "prettier": "^3.2.5",
-    "sinon": "^17.0.1"
+    "sinon": "^17.0.1",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "@octokit/rest": "^21.1.1",

--- a/tools/integration/package.json
+++ b/tools/integration/package.json
@@ -6,6 +6,7 @@
     "test": "npm run mocha && npm run lint",
     "e2e-test-harvest": "mocha test/integration/harvestTest.js",
     "e2e-test-service": "mocha --exit \"test/integration/e2e-test-service/**/*.js\"",
+    "poste2e-test-service": "node ./lib/cleanupPR.js",
     "e2e-test-definition": "mocha --exit \"test/integration/e2e-test-service/definitionTest.js\"",
     "mocha": "mocha --exit \"test/lib/**/*.js\"",
     "lint": "npm run prettier:check && npm run eslint",
@@ -29,6 +30,7 @@
     "sinon": "^17.0.1"
   },
   "dependencies": {
+    "@octokit/rest": "^21.1.1",
     "async-retry": "^1.3.3"
   }
 }

--- a/tools/integration/test/integration/cleanup.js
+++ b/tools/integration/test/integration/cleanup.js
@@ -1,0 +1,8 @@
+// (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+const { cleanupPR } = require('../../lib/cleanupPR')
+const { curation } = require('./testConfig')
+
+cleanupPR(curation)
+  .then(() => console.log('Cleanup completed.'))
+  .catch(error => console.error(`Error during cleanup: ${error.message}`))

--- a/tools/integration/test/integration/e2e-test-service/curationTest.js
+++ b/tools/integration/test/integration/e2e-test-service/curationTest.js
@@ -3,7 +3,7 @@
 
 const { deepStrictEqual, strictEqual, ok } = require('assert')
 const { callFetchWithRetry: callFetch, buildPostOpts } = require('../../../lib/fetch')
-const { devApiBaseUrl, definition } = require('../testConfig')
+const { devApiBaseUrl, definition, curation } = require('../testConfig')
 
 describe('Validate curation', function () {
   this.timeout(definition.timeout)
@@ -12,6 +12,7 @@ describe('Validate curation', function () {
   afterEach(() => new Promise(resolve => setTimeout(resolve, definition.timeout / 2)))
 
   const coordinates = 'maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16'
+  const title = curation.title || `test ${coordinates}`
 
   describe('Propose curation', function () {
     const [type, provider, namespace, name, revision] = coordinates.split('/')
@@ -25,7 +26,7 @@ describe('Validate curation', function () {
     before('curate', async function () {
       const curationResponse = await callFetch(
         `${devApiBaseUrl}/curations`,
-        buildCurationOpts(coordinates, type, provider, namespace, name, revision, curation)
+        buildCurationOpts(title, type, provider, namespace, name, revision, curation)
       ).then(r => r.json())
       prNumber = curationResponse.prNumber
     })
@@ -85,10 +86,10 @@ describe('Validate curation', function () {
   })
 })
 
-function buildCurationOpts(coordinates, type, provider, namespace, name, revision, curation) {
+function buildCurationOpts(title, type, provider, namespace, name, revision, curation) {
   const contributionInfo = {
     type: 'other',
-    summary: `test ${coordinates}`
+    summary: title
   }
   const patch = {
     coordinates: { type, provider, namespace, name },

--- a/tools/integration/test/integration/testConfig.js
+++ b/tools/integration/test/integration/testConfig.js
@@ -88,6 +88,9 @@ module.exports = {
   definition: {
     timeout: 1000 * 60 // for each component
   },
+  curation: {
+    title: 'test maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16'
+  },
   origins: {
     timeout: 1000 * 60 * 2
   }


### PR DESCRIPTION
Our integration tests create a curation pull request (PR), which need to be cleaned up, especially if the tests are to be run regularly. This PR implements a cleanup step for the integration test suite, including closing test curation pull requests generated during the tests.

A successful cleanup log can be found under `Clean up`:
https://github.com/qtomlinson/operations/actions/runs/14918054187/job/41907933077

**Future work:**
- Check whether the improved integration tests on infrastructure need to be updated as well.