### PR TITLE
Update the license file hashes in the fixture for NuGet.Protocol/6.7.1

### DIFF
--- a/tools/integration/test/integration/fixtures/definitions/nuget-nuget---NuGet.Protocol-6.7.1.json
+++ b/tools/integration/test/integration/fixtures/definitions/nuget-nuget---NuGet.Protocol-6.7.1.json
@@ -116,10 +116,10 @@
             "path": "clearlydefined/downloaded/LICENSE",
             "license": "Apache-2.0 AND (ECL-2.0 AND Apache-2.0)",
             "hashes": {
-                "sha1": "6215cb16583ad28f22e1a7c905ee5bbee1044635",
-                "sha256": "e38b0854f4b591f3297571e73c665bd4266e8c8f9c55fb580942e51a4da619a8"
+                "sha1": "39abfb1ed211fe9a9fdef056126133c7eb444f0d",
+                "sha256": "821602941cab0a35e9f461326976dede9239410a988bdcfc88348cc3f57bc6a5"
             },
-            "token": "e38b0854f4b591f3297571e73c665bd4266e8c8f9c55fb580942e51a4da619a8"
+            "token": "821602941cab0a35e9f461326976dede9239410a988bdcfc88348cc3f57bc6a5"
         },
         {
             "path": "lib/net472/NuGet.Protocol.dll",


### PR DESCRIPTION
This pull request resolves a recently failing integration test:  
[GitHub Actions Run](https://github.com/clearlydefined/operations/actions/runs/15086531720/job/42409765031)

#### Issue Summary:  
The failure was caused by a mismatch in the license file's hash values between the expected and actual outputs.

**Expected Output:**  
```json
{
  "path": "clearlydefined/downloaded/LICENSE",
  "license": "Apache-2.0 AND (ECL-2.0 AND Apache-2.0)",
  "hashes": {
    "sha1": "6215cb16583ad28f22e1a7c905ee5bbee1044635",
    "sha256": "e38b0854f4b591f3297571e73c665bd4266e8c8f9c55fb580942e51a4da619a8"
  },
  "token": "e38b0854f4b591f3297571e73c665bd4266e8c8f9c55fb580942e51a4da619a8"
}
```

**Actual Output:**  
```json
{
  "path": "clearlydefined/downloaded/LICENSE",
  "license": "Apache-2.0 AND (ECL-2.0 AND Apache-2.0)",
  "hashes": {
    "sha1": "39abfb1ed211fe9a9fdef056126133c7eb444f0d",
    "sha256": "821602941cab0a35e9f461326976dede9239410a988bdcfc88348cc3f57bc6a5"
  },
  "token": "821602941cab0a35e9f461326976dede9239410a988bdcfc88348cc3f57bc6a5"
}
```

#### Root Cause Analysis:  

By comparing the license files on the dev and prod deployments, it was determined that the difference stems from:  
1. A slight change in CSS classes.  
2. A difference in the date displayed at the bottom of the file:  
   - **Dev Deployment:** November 6, 2024  
   - **Prod Deployment:** February 9, 2023  

URLs for reference:  
- [Dev Deployment File](https://dev.clearlydefined.io/file/821602941cab0a35e9f461326976dede9239410a988bdcfc88348cc3f57bc6a5)  
- [Prod Deployment File](https://clearlydefined.io/file/e38b0854f4b591f3297571e73c665bd4266e8c8f9c55fb580942e51a4da619a8)  

The license file being downloaded originates from the [NuGet license page](https://licenses.nuget.org/Apache-2.0), and the current version matches the date on the dev deployment.

#### Resolution:  
This pull request updates the test fixture to reflect the changes in the license file, ensuring the integration test passes with the latest version.