### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      azure-actions:
+        patterns:
+          - 'azure/*'
+      docker-actions:
+        patterns:
+          - 'docker/*'
+      github-actions:
+        patterns:
+          - 'actions/*'
+          - 'github/*'


### PR DESCRIPTION
This mirrors the existing configuration in [`clearlydefined/service`][1]

[1]: https://github.com/clearlydefined/service/blob/master/.github/dependabot.yml
