### PR TITLE
Fix failing Debian test case for mini-httpd

### DIFF
--- a/tools/integration/test/integration/testConfig.js
+++ b/tools/integration/test/integration/testConfig.js
@@ -33,8 +33,8 @@ const componentsStatic = [
   'nuget/nuget/-/NuGet.Protocol/6.7.1',
   'composer/packagist/symfony/polyfill-mbstring/v1.28.0',
   'pod/cocoapods/-/SoftButton/0.1.0', // Dev and prod have different file counts. See https://github.com/clearlydefined/crawler/issues/529
-  'deb/debian/-/mini-httpd/1.30-0.2_arm64',
-  'debsrc/debian/-/mini-httpd/1.30-0.2',
+  'deb/debian/-/mini-httpd/1.30-13_armhf',
+  'debsrc/debian/-/mini-httpd/1.30-13',
   'pod/cocoapods/-/xcbeautify/0.9.1'
   // 'sourcearchive/mavencentral/org.apache.httpcomponents/httpcore/4.1' // Dev and prod have different license and scores. See https://github.com/clearlydefined/crawler/issues/533
 ]


### PR DESCRIPTION
### **Description**
During our CI runs, the Debian test case for mini-httpd/1.30-0.2 has been failing.
See the failing workflow:
https://github.com/clearlydefined/operations/actions/runs/16382766911/job/46297303976

### **Error message:**
Debian: got 0 entries for cd:/debsrc/debian/-/mini-httpd/1.30-0.2

### **Cause**
The version (1.30-0.2) for mini-httpd used in our test suite is no longer available in the Debian package repo.
See: http://ftp.debian.org/debian/pool/main/m/mini-httpd/

**### Resolution**
There are newer versions (e.g., 1.30-2 and above) available. This PR updates the test config to use a currently available version to restore CI pass (successful harvest).

**### Checklist**

- [x]  Update test configuration to use mini-httpd/1.30-13
- [x]  Confirm tests now pass in CI
