### PR TITLE
Updated license comparison logic for sequence failures

### DIFF
--- a/tools/integration/lib/compareDefinitions.js
+++ b/tools/integration/lib/compareDefinitions.js
@@ -1,6 +1,7 @@
 // (c) Copyright 2024, GitHub and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+const SPDX = require('@clearlydefined/spdx')
 function compareDocuments(staging, production, ignoredKeys, path = '') {
   let differences = {}
   let overallResults = []
@@ -215,4 +216,8 @@ function getType(value) {
   return typeof value
 }
 
-module.exports = { compareDocuments }
+function normalizeLicenseExpression(license) {
+  return license ? SPDX.expand(license).sort() : license
+}
+
+module.exports = { compareDocuments, normalizeLicenseExpression }

--- a/tools/integration/package-lock.json
+++ b/tools/integration/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@clearlydefined/spdx": "^0.1.7",
         "@octokit/rest": "^21.1.1",
         "async-retry": "^1.3.3"
       },
@@ -33,6 +34,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@clearlydefined/spdx": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@clearlydefined/spdx/-/spdx-0.1.7.tgz",
+      "integrity": "sha512-omlCkOl6FvJV3NbrReZdqhmXa/Ls3D4vvgSBNsTZpeQzcksKqMLof5vcN3j3jSXwePDrLTJKOj6818rN/WeY8Q==",
+      "dependencies": {
+        "spdx-expression-parse": "github:clearlydefined/spdx-expression-parse.js#fork",
+        "spdx-license-ids": "^3.0.13",
+        "spdx-license-list": "^6.6.0",
+        "spdx-satisfies": "github:clearlydefined/spdx-satisfies.js#parse-override"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -474,6 +486,14 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -1936,6 +1956,61 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dependencies": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/clearlydefined/spdx-expression-parse.js.git#f848e37e6fb9e8de610e378180fcf875e23f9b36",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.5.0",
+        "spdx-license-ids": "^3.0.21"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="
+    },
+    "node_modules/spdx-license-list": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.10.0.tgz",
+      "integrity": "sha512-wF3RhDFoqdu14d1Prv6c8aNU0FSRuSFJpNjWeygIZcNZEwPxp7I5/Hwo8j6lSkBKWAIkSQrKefrC5N0lvOP0Gw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA=="
+    },
+    "node_modules/spdx-satisfies": {
+      "version": "5.0.0",
+      "resolved": "git+ssh://git@github.com/clearlydefined/spdx-satisfies.js.git#b9571c0180dd95f160e7ddd522761c9e6a153259",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
       }
     },
     "node_modules/string-width": {

--- a/tools/integration/package.json
+++ b/tools/integration/package.json
@@ -33,6 +33,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@clearlydefined/spdx": "^0.1.7",
     "@octokit/rest": "^21.1.1",
     "async-retry": "^1.3.3"
   }

--- a/tools/integration/test/integration/e2e-test-service/definitionTest.js
+++ b/tools/integration/test/integration/e2e-test-service/definitionTest.js
@@ -8,6 +8,7 @@ const { devApiBaseUrl, prodApiBaseUrl, getComponents, definition, fetchRetry } =
 const nock = require('nock')
 const fs = require('fs')
 const callFetch = createFetcherWithRetry(fetchRetry)
+const { normalizeLicenseExpression } = require('../../../lib/compareDefinitions')
 
 ;(async function () {
   const components = await getComponents()
@@ -89,10 +90,12 @@ function compareDefinition(recomputedDef, expectedDef) {
 }
 
 function compareLicensed(result, expectation) {
-  let actual = omit(result.licensed, ['facets'])
-  let expected = omit(expectation.licensed, ['facets'])
-  actual = { declared: undefined, ...actual }
-  expected = { declared: undefined, ...expected }
+  deepStrictEqual(
+    normalizeLicenseExpression(result.licensed.declared),
+    normalizeLicenseExpression(expectation.licensed.declared)
+  )
+  let actual = omit(result.licensed, ['facets', 'declared'])
+  let expected = omit(expectation.licensed, ['facets', 'declared'])
   deepStrictEqualExpectedEntries(actual, expected)
 }
 
@@ -107,13 +110,20 @@ function deepStrictEqualExpectedEntries(actual, expected) {
   deepStrictEqual(pickedActual, expected)
 }
 
+function compareFileLicense(expectedFiles, f) {
+  const expected = expectedFiles.get(f.path)
+  const licenseComp = isEqual(normalizeLicenseExpression(f.license), normalizeLicenseExpression(expected.license))
+  const normResult = omit(f, ['license'])
+  const normExpect = omit(expected, ['license'])
+  return !(isEqual(normResult, normExpect) && licenseComp)
+}
+
 function compareFiles(result, expectation) {
   const resultFiles = filesToMap(result)
   const expectedFiles = filesToMap(expectation)
   const extraInResult = result.files.filter(f => !expectedFiles.has(f.path))
   const missingInResult = expectation.files.filter(f => !resultFiles.has(f.path))
-  const differentEntries = result.files.filter(f => expectedFiles.has(f.path) && !isEqual(expectedFiles.get(f.path), f))
-
+  const differentEntries = result.files.filter(f => expectedFiles.has(f.path) && compareFileLicense(expectedFiles, f))
   const differences = [...extraInResult, ...missingInResult, ...differentEntries]
   differences.forEach(f => logDifferences(expectedFiles.get(f.path), resultFiles.get(f.path)))
 

--- a/tools/integration/test/lib/compareDefinition.js
+++ b/tools/integration/test/lib/compareDefinition.js
@@ -1,0 +1,47 @@
+const assert = require('assert')
+const { normalizeLicenseExpression } = require('../../lib/compareDefinitions')
+
+describe('normalizeLicenseExpression', () => {
+  it('should treat (MIT OR Apache-2.0) and (Apache-2.0 OR MIT) as equivalent', () => {
+    assert.deepStrictEqual(
+      normalizeLicenseExpression('(MIT OR Apache-2.0)'),
+      normalizeLicenseExpression('(Apache-2.0 OR MIT)')
+    )
+  })
+
+  it('should treat ( LGPL-2.1-only OR MIT) AND Apache-2.0 and ( MIT OR LGPL-2.1-only) AND Apache-2.0 as equivalent', () => {
+    const actual1 = '( LGPL-2.1-only OR MIT) AND Apache-2.0'
+    const expected1 = '( MIT OR LGPL-2.1-only) AND Apache-2.0'
+    assert.deepStrictEqual(normalizeLicenseExpression(actual1), normalizeLicenseExpression(expected1))
+  })
+
+  it('should treat (LGPL-2.1-only OR MIT) AND Apache-2.0 and (LGPL-2.1-only OR MIT) AND Apache-2.0 as equivalent', () => {
+    const actual2 = '(LGPL-2.1-only OR MIT) AND Apache-2.0'
+    const expected2 = '(LGPL-2.1-only OR MIT) AND Apache-2.0'
+    assert.deepStrictEqual(normalizeLicenseExpression(actual2), normalizeLicenseExpression(expected2))
+  })
+
+  it('should treat (LGPL-2.1-only OR MIT) OR Apache-2.0 and (MIT OR LGPL-2.1-only) OR Apache-2.0 as equivalent', () => {
+    const actual3 = '(LGPL-2.1-only OR MIT) OR Apache-2.0'
+    const expected3 = '(MIT OR LGPL-2.1-only) OR Apache-2.0'
+    assert.deepStrictEqual(normalizeLicenseExpression(actual3), normalizeLicenseExpression(expected3))
+  })
+
+  it('should treat (LGPL-2.1-only OR Apache-2.0) OR MIT and (MIT OR LGPL-2.1-only) OR Apache-2.0 as equivalent', () => {
+    const actual4 = '(LGPL-2.1-only OR Apache-2.0) OR MIT'
+    const expected4 = '(MIT OR LGPL-2.1-only) OR Apache-2.0'
+    assert.deepStrictEqual(normalizeLicenseExpression(actual4), normalizeLicenseExpression(expected4))
+  })
+
+  it('should treat ( LGPL-2.1-only OR MIT) AND Apache-2.0 and Apache-2.0 AND ( MIT OR LGPL-2.1-only) as equivalent', () => {
+    const actual6 = '( LGPL-2.1-only OR MIT) AND Apache-2.0'
+    const expected6 = 'Apache-2.0 AND ( MIT OR LGPL-2.1-only)'
+    assert.deepStrictEqual(normalizeLicenseExpression(actual6), normalizeLicenseExpression(expected6))
+  })
+
+  it('should NOT treat (LGPL-2.1-only OR Apache-2.0) AND MIT and (MIT OR LGPL-2.1-only) OR Apache-2.0 as equivalent', () => {
+    const actual5 = '(LGPL-2.1-only OR Apache-2.0) AND MIT'
+    const expected5 = '(MIT OR LGPL-2.1-only) OR Apache-2.0'
+    assert.notDeepStrictEqual(normalizeLicenseExpression(actual5), normalizeLicenseExpression(expected5))
+  })
+})


### PR DESCRIPTION
# Summary

This PR updates the license comparison logic within the integration test suite to be more robust against sequence (order) variations in license expressions. Previously, tests were failing due to differences in the order of license identifiers, even when the actual licenses were equivalent.

## Details

- **Introduced `SPDX.expand` for license comparison**
    - The license comparison now utilizes the `@clearlydefined/spdx` package to expand and sort license expressions before performing equality checks.
    - This approach ensures that sequence/order differences do not cause test failures.
- **Adjusted file-level license checks**
    - Updated the logic for comparing license fields in files within integration tests, so license values are expanded and sorted prior to comparison.
    - This prevents mismatch errors from inconsequential sequence variations in license expressions.
- **Dependency and lock file updates**
    - Added `@clearlydefined/spdx` as a new dependency in `package.json`.
    - Updated `package-lock.json` as required.

## Rationale

Comparing license expressions based solely on their sequence can cause false negatives in our tests. This update makes our test suite more robust and ensures we only fail on true differences, not on license string orderings that are semantically equivalent.

## Checklist

- [x] License comparison logic normalized using SPDX utilities
- [x] Test suite covers expanded license comparison scenarios
- [x] Dependency added/updated as needed
