### PR TITLE
Fix storage container name for definitions

### DIFF
--- a/tools/blobstorage-backupdata/README.MD
+++ b/tools/blobstorage-backupdata/README.MD
@@ -27,7 +27,7 @@ The files contained in the storage container can be split into two categories:
 ### Definition files
 Definition files are named after ClearlyDefined coordinates with a `.json` extension, e.g.
 `pypi/pypi/-/opentelemetry-api/1.21.0.json`. They are contained in the root directory of the
-`production-snapshots` storage container. They can be read individually, but not listed.
+`changes-notifications` storage container. They can be read individually, but not listed.
 
 Each definition file contain a JSON representation of a ClearlyDefined package definition,
 excluding the `files` part.


### PR DESCRIPTION
In 38e3197a6e66a96cab9a2b15f5e547ee7570a671 the name of the storage container was updated to `changes-notifications`, but the name in the definitions subsection remained `production-snapshots`. Based on lightweight experimentation with the `changes-notifications` storage container, I'm able to retrieve definitions from the root of the container and therefore assume the the README should also recommend using the `changes-notifications` container for retrieving definitions.